### PR TITLE
fix: add missing python-dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "pydantic>=2.11.4",
     "uvicorn>=0.34.2",
     "python-multipart>=0.0.18",
+    "python-dotenv>=1.2.2",
 ]


### PR DESCRIPTION
## Summary

- Add `python-dotenv` to `pyproject.toml`.
- Align the `uv sync` backend setup with `api/index.py`, which imports `dotenv` and calls `load_dotenv()`.
- Avoid relying on `requirements.txt`, global Python packages, or manual pip installs.

## Verification

- `uv sync`
- `uv run python -c "from dotenv import load_dotenv; print('python-dotenv OK')"`
- `op run --env-file /Users/orbula-admin/AI-Maker-Space/.env.openai -- uv run uvicorn api.index:app --reload`
- `curl -sS -X POST http://127.0.0.1:8000/api/chat -H 'Content-Type: application/json' -d '{"message":"Say hello in one short sentence."}'`
- Response: `{"reply":"Hello, I’m here for you."}`

## Security

- No raw OpenAI API key was committed.
- Runtime key injection was tested locally using 1Password `op run` with a local env-reference file outside the repository.
- Future users can clone the repo and provide their own `OPENAI_API_KEY` through their preferred local secret mechanism.
