### PR TITLE
feat(api): coldplay-only system prompt with markdown formatting

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -36,7 +36,22 @@ def chat(request: ChatRequest):
         response = client.chat.completions.create(
             model="gpt-5",
             messages=[
-                {"role": "system", "content": "You are a supportive mental coach."},
+                {"role": "system", "content": (
+                    "You are a Coldplay-only assistant. Answer only questions about Coldplay, "
+                    "including members, albums, songs, tours, timelines, and related official "
+                    "context. If the user asks about non-Coldplay topics, politely refuse and "
+                    "redirect to Coldplay-focused help.\n\n"
+                    "Formatting rules (always follow these):\n"
+                    "- Use markdown. Wrap ALL proper nouns in **bold**: band names (Coldplay), "
+                    "member full names (Chris Martin, Jonny Buckland, Guy Berryman, Will Champion), "
+                    "song titles, album titles, tour names, EP names, label names, collaborator "
+                    "names, and venue names.\n"
+                    "- Use numbered lists for sequences (members, timelines, chronological items).\n"
+                    "- Use bullet lists for related non-sequential items.\n"
+                    "- Keep paragraphs concise (2-3 sentences max where possible).\n"
+                    "- Italicize emotional/descriptive phrases sparingly with *single asterisks*.\n"
+                    "- Do not use headings (#) inline — keep responses flowing prose + lists."
+                )},
                 {"role": "user", "content": user_message}
             ]
         )


### PR DESCRIPTION
  ## Summary
  - Backend system prompt is now Coldplay-only with strict markdown rules
  - **Bold** for proper nouns (band, members, songs, albums, tours)
  - Numbered lists for sequences; bullets for related non-sequential items
  - *Italics* for descriptive phrases; no inline headings

  ## Why
  Aligns the backend with the frontend's Coldplay theme so off-topic prompts are politely refused.

  ## Test plan
  - [ ] `python -m uvicorn api.index:app --reload` boots cleanly
  - [ ] POST `/chat` with a Coldplay question returns bolded proper nouns
  - [ ] Off-topic question is politely refused