### PR TITLE
fix(frontend): remove orphan BackendConnectionPanel import

### DIFF
--- a/frontend/components/chat-shell.tsx
+++ b/frontend/components/chat-shell.tsx
@@ -3,7 +3,6 @@
 import { FormEvent, useEffect, useRef, useState, useTransition } from "react";
 
 import { verifyOpenAiKeyAction } from "@/app/actions";
-import { BackendConnectionPanel } from "@/components/backend-connection-panel";
 import { ChatComposer } from "@/components/chat-composer";
 import { ConnectionStatusCard } from "@/components/connection-status-card";
 import { MessageList } from "@/components/message-list";
@@ -200,14 +199,7 @@ export function ChatShell() {
         />
 
         <div className="relative">
-          {showBackendPanel ? (
-            <div className="panel-enter">
-              <BackendConnectionPanel
-                backendBaseUrl={backendBaseUrl}
-                verificationMessage="Key verified. You can start chatting."
-              />
-            </div>
-          ) : (
+          {showBackendPanel ? null : (
             <Card
               aria-label="OpenAI key verification"
               className={cn(isSwappingPanel ? "panel-exit" : "panel-enter")}


### PR DESCRIPTION
## Summary
- PR 1's last commit (`true single-glass shell + slim status header`) deleted `frontend/components/backend-connection-panel.tsx` but left the import statement in `frontend/components/chat-shell.tsx` (line 6) and a usage at line 205.
- Every Turbopack build on `main` has failed since with `Module not found: Can't resolve '@/components/backend-connection-panel'`, blocking all Vercel preview and production deployments — including PR #5 (the Coldplay backend prompt PR).
- This PR removes the orphan import and replaces the now-dead truthy branch of the `showBackendPanel` ternary with `null`. That matches the hero-first refactor's intent: the connect-panel UI was supposed to disappear once the key is verified.
- Dead `showBackendPanel` / `isSwappingPanel` state is intentionally left alone — PR 5 (chat-shell decomposition) deletes this whole file.

## Why this is urgent
Production deployments from `main` have been broken since PR #4 merged. This unblocks PR #5 and every subsequent PR's preview build.

## Test plan
- [ ] `pnpm run build` succeeds locally (verified: TypeScript compiles with `tsc --noEmit`; only sandbox port-binding blocked the local Turbopack run)
- [ ] Vercel preview build on this PR turns green
- [ ] After merge, production deploy from `main` succeeds