### PR TITLE
feat(frontend): zod schemas at every trust boundary

### DIFF
--- a/frontend/lib/chat-state.ts
+++ b/frontend/lib/chat-state.ts
@@ -1,4 +1,10 @@
-import { ChatMessage } from "@/lib/chat-types";
+import type { ChatMessage } from "@/lib/chat-types";
+
+interface CreateMessageOptions {
+  animate?: boolean;
+  createdAt?: number;
+  typingMs?: number;
+}
 
 export function createMessageId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -8,20 +14,29 @@ export function createMessageId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export function createUserMessage(content: string): ChatMessage {
+export function createUserMessage(
+  content: string,
+  options: CreateMessageOptions = {}
+): ChatMessage {
   return {
     id: createMessageId(),
     role: "user",
-    content
+    content,
+    createdAt: options.createdAt ?? Date.now(),
   };
 }
 
-export function createAssistantMessage(content: string): ChatMessage {
+export function createAssistantMessage(
+  content: string,
+  options: CreateMessageOptions = {}
+): ChatMessage {
   return {
     id: createMessageId(),
     role: "assistant",
     content,
-    animate: true
+    createdAt: options.createdAt ?? Date.now(),
+    animate: options.animate ?? true,
+    typingMs: options.typingMs,
   };
 }
 

--- a/frontend/lib/chat-types.ts
+++ b/frontend/lib/chat-types.ts
@@ -1,8 +1,6 @@
-export type Role = "user" | "assistant";
-
-export interface ChatMessage {
-  id: string;
-  role: Role;
-  content: string;
-  animate?: boolean;
-}
+/**
+ * Domain types are inferred from zod schemas (single source of truth).
+ * This file exists for backwards-compatible imports — new code should
+ * import directly from `@/lib/schemas`.
+ */
+export type { ChatMessage, ChatRequest, PersistedChatUiState, Role } from "@/lib/schemas";

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+/**
+ * Single source of truth for all runtime validation at trust boundaries:
+ *  - Server actions (`app/actions.ts`)
+ *  - API route handlers (`app/api/chat/route.ts`)
+ *  - Client fetch responses (`lib/chat-client.ts`)
+ *  - sessionStorage hydration (`components/chat-shell.tsx`)
+ *
+ * Static types are derived via `z.infer<>` so editing a schema updates all
+ * call-site types simultaneously — no parallel type/schema drift.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain — chat messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const roleSchema = z.enum(["user", "assistant"]);
+
+export const chatMessageSchema = z.object({
+  id: z.string().min(1),
+  role: roleSchema,
+  content: z.string(),
+  createdAt: z.number().finite(),
+  animate: z.boolean().optional(),
+  typingMs: z.number().finite().positive().optional(),
+});
+
+export type Role = z.infer<typeof roleSchema>;
+export type ChatMessage = z.infer<typeof chatMessageSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — POST /api/chat request body
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const chatRequestSchema = z.object({
+  message: z.string().trim().min(1, "Message cannot be empty.").max(4000, "Message is too long."),
+});
+
+export type ChatRequest = z.infer<typeof chatRequestSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — OpenAI key verification input
+// ─────────────────────────────────────────────────────────────────────────────
+
+const OPENAI_KEY_MIN_LENGTH = 24;
+const OPENAI_KEY_MAX_LENGTH = 256;
+
+export const verifyKeyInputSchema = z
+  .string()
+  .trim()
+  .min(OPENAI_KEY_MIN_LENGTH)
+  .max(OPENAI_KEY_MAX_LENGTH)
+  .refine((value) => value.startsWith("sk-"), {
+    message: "OpenAI keys must start with 'sk-'.",
+  });
+
+/** Pure predicate used in non-throwing checks (cookie hydration). */
+export function isPlausibleOpenAiKey(value: string): boolean {
+  return verifyKeyInputSchema.safeParse(value).success;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — sessionStorage persisted chat UI state
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const persistedChatUiStateSchema = z.object({
+  messages: z.array(chatMessageSchema),
+  inputValue: z.string(),
+});
+
+export type PersistedChatUiState = z.infer<typeof persistedChatUiStateSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — OpenAI SSE chunk envelope
+// (only the fields we depend on; OpenAI may add more without breaking us)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const openAiStreamChunkSchema = z.object({
+  choices: z
+    .array(
+      z.object({
+        delta: z
+          .object({
+            content: z.string().optional(),
+          })
+          .passthrough(),
+      })
+    )
+    .min(1),
+});
+
+export type OpenAiStreamChunk = z.infer<typeof openAiStreamChunkSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — OpenAI error response envelope
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const openAiErrorResponseSchema = z.object({
+  error: z.object({
+    message: z.string().min(1),
+  }),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boundary — client fetch error response (from /api/chat)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const chatErrorResponseSchema = z.object({
+  detail: z.string().min(1),
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "react-dom": "latest",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.15


### PR DESCRIPTION
## Summary
- New `lib/schemas.ts` — **single source of truth** for runtime validation at every boundary:
  - `chatRequestSchema` — `POST /api/chat` request body (trim, min 1, max 4000 chars)
  - `chatMessageSchema` — domain message (`id`, `role`, `content`, `createdAt`, optional `animate`/`typingMs`)
  - `verifyKeyInputSchema` + `isPlausibleOpenAiKey` — OpenAI key shape check (`sk-...`, 24–256 chars)
  - `persistedChatUiStateSchema` — sessionStorage hydration envelope
  - `openAiStreamChunkSchema` + `openAiErrorResponseSchema` — upstream OpenAI SSE + error
  - `chatErrorResponseSchema` — `/api/chat` error body
- **Static types derive via `z.infer<>`** — no parallel type/schema drift, ever
- `lib/chat-types.ts` re-exports from `@/lib/schemas` (back-compat shim)
- `lib/chat-state.ts` factory functions (`createUserMessage`/`createAssistantMessage`) return messages that satisfy the schema
- Adds `zod` `^4.4.3` to dependencies

## Why
Trust boundaries (server actions, API routes, persisted state, third-party APIs) must validate untrusted input. Centralizing in one schemas file prevents drift, makes the trust surface auditable, and means TS types and runtime checks never disagree.

## Out of scope (intentional)
- **`chat-client.ts` streaming refactor** — moves to streaming `/api/chat` calls in PR 7 (cookie security) where the route handler is introduced. Including it now would break `chat-shell.tsx` imports and 404 at runtime (route doesn't exist yet).
- **PR 5 chat-shell decomposition** — the `lib/hooks/use-chat-persistence` and `use-chat-streaming` hooks that consume these schemas land in PR 5.
- **No new components or routes** — pure schema introduction.

## Test plan
- [ ] `pnpm install` resolves cleanly with `zod ^4.4.3`
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0 against the full tree)
- [ ] Vercel preview turns green
- [ ] After merge: existing chat UI keeps working (factory functions are backwards-compatible — `createdAt` defaults to `Date.now()`)