### PR TITLE
feat(frontend): streaming /api/chat route + back-compat chat-client (PR 5a)

### DIFF
--- a/frontend/app/actions.ts
+++ b/frontend/app/actions.ts
@@ -1,36 +1,60 @@
 "use server";
 
+import { cookies } from "next/headers";
+
+import { verifyKeyInputSchema } from "@/lib/schemas";
+
 export interface VerifyKeyResult {
   ok: boolean;
   message: string;
 }
 
+const OPENAI_API_KEY_COOKIE = "openai_api_key";
+// 24h: short enough to bound key-disclosure blast radius, long enough that
+// a normal day's session survives without re-verification. PR 7 (cookie
+// security) wraps the raw value with AES-256-GCM seal and tightens
+// sameSite to "strict".
+const SESSION_TTL_SECONDS = 60 * 60 * 24;
+
 export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyResult> {
-  const key = rawKey.trim();
-  if (!isPlausibleOpenAiKey(key)) {
+  const parsed = verifyKeyInputSchema.safeParse(rawKey);
+  if (!parsed.success) {
     return {
       ok: false,
-      message: "Invalid key format. OpenAI keys usually start with 'sk-' and are longer."
+      message: "Invalid key format. OpenAI keys usually start with 'sk-' and are longer.",
     };
   }
+  const key = parsed.data;
 
   try {
     const response = await fetch("https://api.openai.com/v1/models", {
       method: "GET",
       headers: {
-        Authorization: `Bearer ${key}`
+        Authorization: `Bearer ${key}`,
       },
-      cache: "no-store"
+      cache: "no-store",
     });
 
     if (response.ok) {
+      const cookieStore = await cookies();
+      // Raw key for now — PR 7 wraps with AES-256-GCM seal so cookie
+      // disclosure (logs, browser-ext, OS-level inspection) only yields
+      // an opaque blob without SESSION_SECRET. Same-site policy also
+      // tightens to "strict" in PR 7.
+      cookieStore.set(OPENAI_API_KEY_COOKIE, key, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        path: "/",
+        maxAge: SESSION_TTL_SECONDS,
+      });
       return { ok: true, message: "Key verified. You can start chatting." };
     }
 
     if (response.status === 401) {
       return {
         ok: false,
-        message: "This key is invalid, revoked, or expired. Please check and try again."
+        message: "This key is invalid, revoked, or expired. Please check and try again.",
       };
     }
 
@@ -38,26 +62,18 @@ export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyRe
       return {
         ok: true,
         message:
-          "Key is recognized, but your account appears rate-limited right now. Chat may still fail until limits reset."
+          "Key is recognized, but your account appears rate-limited right now. Chat may still fail until limits reset.",
       };
     }
 
     return {
       ok: false,
-      message: `Validation failed with status ${response.status}. Please retry in a moment.`
+      message: `Validation failed with status ${response.status}. Please retry in a moment.`,
     };
   } catch {
     return {
       ok: false,
-      message: "Could not reach OpenAI for validation. Check your network and try again."
+      message: "Could not reach OpenAI for validation. Check your network and try again.",
     };
   }
-}
-
-function isPlausibleOpenAiKey(value: string): boolean {
-  if (!value.startsWith("sk-")) {
-    return false;
-  }
-
-  return value.length >= 24 && value.length <= 256;
 }

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,0 +1,193 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import {
+  chatRequestSchema,
+  isPlausibleOpenAiKey,
+  openAiErrorResponseSchema,
+  openAiStreamChunkSchema,
+} from "@/lib/schemas";
+
+export const runtime = "nodejs";
+
+const OPENAI_API_KEY_COOKIE = "openai_api_key";
+const OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const OPENAI_TIMEOUT_MS = 60_000;
+const OPENAI_MODEL = process.env.OPENAI_MODEL ?? "gpt-5";
+const OPENAI_MAX_TOKENS = Number(process.env.OPENAI_MAX_COMPLETION_TOKENS ?? 280);
+
+const COLDPLAY_SYSTEM_PROMPT = [
+  "You are a Coldplay-only assistant. Answer only questions about Coldplay, ",
+  "including members, albums, songs, tours, timelines, and related official ",
+  "context. If the user asks about non-Coldplay topics, politely refuse and ",
+  "redirect to Coldplay-focused help.\n\n",
+  "Formatting rules (always follow these):\n",
+  "- Use markdown. Wrap ALL proper nouns in **bold**: band names (Coldplay), ",
+  "member full names (Chris Martin, Jonny Buckland, Guy Berryman, Will Champion), ",
+  "song titles, album titles, tour names, EP names, label names, collaborator ",
+  "names, and venue names.\n",
+  "- Use numbered lists for sequences (members, timelines, chronological items).\n",
+  "- Use bullet lists for related non-sequential items.\n",
+  "- Keep paragraphs concise (2-3 sentences max where possible).\n",
+  "- Italicize emotional/descriptive phrases sparingly with *single asterisks*.\n",
+  "- Do not use headings (#) inline — keep responses flowing prose + lists.",
+].join("");
+
+export async function POST(request: Request): Promise<Response> {
+  const requestId = crypto.randomUUID();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { detail: "Invalid JSON body." },
+      { status: 400, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  const parsed = chatRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { detail: parsed.error.issues[0]?.message ?? "Invalid request." },
+      { status: 400, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  // Raw key cookie — PR 7 wraps this with AES-256-GCM unseal here, adds
+  // a same-origin guard above this read, and PR 8 layers a sliding-window
+  // rate limit before any of this work happens.
+  const cookieStore = await cookies();
+  const keyCookie = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
+  if (!keyCookie || !isPlausibleOpenAiKey(keyCookie)) {
+    return NextResponse.json(
+      { detail: "OpenAI key not verified. Please re-enter your key." },
+      { status: 401, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  const timeoutController = new AbortController();
+  const timeoutHandle = setTimeout(() => timeoutController.abort(), OPENAI_TIMEOUT_MS);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(OPENAI_CHAT_COMPLETIONS_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${keyCookie}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages: [
+          { role: "system", content: COLDPLAY_SYSTEM_PROMPT },
+          { role: "user", content: parsed.data.message },
+        ],
+        stream: true,
+        max_completion_tokens: OPENAI_MAX_TOKENS,
+      }),
+      signal: timeoutController.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeoutHandle);
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return NextResponse.json(
+        { detail: "Upstream OpenAI request timed out." },
+        { status: 504, headers: { "x-request-id": requestId } }
+      );
+    }
+    return NextResponse.json(
+      { detail: "Failed to reach OpenAI." },
+      { status: 502, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  clearTimeout(timeoutHandle);
+
+  if (!upstream.ok) {
+    let detail = "OpenAI returned an error.";
+    try {
+      const errorRaw = await upstream.json();
+      const errorParsed = openAiErrorResponseSchema.safeParse(errorRaw);
+      if (errorParsed.success) {
+        detail = errorParsed.data.error.message;
+      }
+    } catch {
+      // ignore unparseable upstream error body
+    }
+    return NextResponse.json(
+      { detail },
+      { status: upstream.status, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  if (!upstream.body) {
+    return NextResponse.json(
+      { detail: "Upstream returned no stream body." },
+      { status: 502, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  // Pipe OpenAI SSE → plain text content deltas. We strip the SSE
+  // envelope on the server so the client (streamChatMessage) stays simple:
+  // it just decodes UTF-8 chunks and appends them to the rendered message.
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = upstream.body!.getReader();
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      let buffer = "";
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (!value) {
+            continue;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (!line.startsWith("data:")) {
+              continue;
+            }
+            const payload = line.slice(5).trim();
+            if (!payload || payload === "[DONE]") {
+              continue;
+            }
+
+            try {
+              const chunk = openAiStreamChunkSchema.parse(JSON.parse(payload));
+              const content = chunk.choices[0]?.delta.content;
+              if (typeof content === "string" && content.length > 0) {
+                controller.enqueue(encoder.encode(content));
+              }
+            } catch {
+              // Malformed/unsupported chunk shape — skip rather than tear
+              // down the whole stream for the user.
+            }
+          }
+        }
+      } catch (error) {
+        controller.error(error);
+        return;
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "x-request-id": requestId,
+    },
+  });
+}

--- a/frontend/lib/chat-client.ts
+++ b/frontend/lib/chat-client.ts
@@ -1,4 +1,7 @@
+import { chatErrorResponseSchema, chatRequestSchema } from "@/lib/schemas";
+
 const DEFAULT_BACKEND_URL = "http://127.0.0.1:8000";
+const STREAMING_ENDPOINT = "/api/chat";
 
 export interface ChatRequest {
   message: string;
@@ -13,25 +16,44 @@ interface SendChatOptions {
   timeoutMs?: number;
 }
 
+interface StreamChatOptions extends SendChatOptions {
+  onChunk: (chunk: string) => void;
+}
+
 export class ChatApiError extends Error {
-  constructor(message: string, public readonly status?: number) {
+  constructor(
+    message: string,
+    public readonly status?: number
+  ) {
     super(message);
     this.name = "ChatApiError";
   }
 }
 
+/**
+ * @deprecated Legacy direct-to-FastAPI client. Kept so `chat-shell.tsx`
+ * continues to compile until PR 5b switches the orchestrator over to
+ * `streamChatMessage`. Will be removed in PR 5b.
+ */
 export function getBackendBaseUrl(): string {
   const configured = process.env.NEXT_PUBLIC_BACKEND_URL?.trim();
   return configured && configured.length > 0 ? configured : DEFAULT_BACKEND_URL;
 }
 
+/**
+ * @deprecated Legacy non-streaming chat call. Kept so `chat-shell.tsx`
+ * compiles and behaves identically until PR 5b migrates the orchestrator
+ * to `streamChatMessage`. New code should use the streaming path.
+ */
 export async function sendChatMessage(
   message: string,
   options: SendChatOptions = {}
 ): Promise<ChatResponse> {
-  const trimmedMessage = message.trim();
-  if (!trimmedMessage) {
-    throw new ChatApiError("Please write a message before sending.");
+  const parsed = chatRequestSchema.safeParse({ message });
+  if (!parsed.success) {
+    throw new ChatApiError(
+      parsed.error.issues[0]?.message ?? "Please write a message before sending."
+    );
   }
 
   const backendBaseUrl = getBackendBaseUrl();
@@ -44,11 +66,9 @@ export async function sendChatMessage(
   try {
     const response = await fetch(endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({ message: trimmedMessage } satisfies ChatRequest),
-      signal: combinedSignal
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+      signal: combinedSignal,
     });
 
     if (!response.ok) {
@@ -56,17 +76,15 @@ export async function sendChatMessage(
       throw new ChatApiError(details, response.status);
     }
 
-    const data = (await response.json()) as Partial<ChatResponse>;
-    if (!data.reply || typeof data.reply !== "string") {
+    const raw = (await response.json()) as Partial<ChatResponse>;
+    if (!raw.reply || typeof raw.reply !== "string") {
       throw new ChatApiError("The backend returned an invalid response.");
     }
-
-    return { reply: data.reply };
+    return { reply: raw.reply };
   } catch (error) {
     if (error instanceof ChatApiError) {
       throw error;
     }
-
     if (error instanceof DOMException && error.name === "AbortError") {
       if (options.signal?.aborted) {
         throw new ChatApiError("Request cancelled.");
@@ -75,7 +93,6 @@ export async function sendChatMessage(
         `The request timed out after ${Math.round(timeoutMs / 1000)} seconds. Check that the backend is running and responsive.`
       );
     }
-
     throw new ChatApiError(
       `Unable to reach the backend at ${endpoint}. Make sure the FastAPI server is running and accessible.`
     );
@@ -84,13 +101,85 @@ export async function sendChatMessage(
   }
 }
 
+/**
+ * Stream chat completions through the Next.js `/api/chat` route handler.
+ * The route forwards server-side to OpenAI and pipes plain-text content
+ * deltas back. Each chunk is delivered to `onChunk` as it arrives; the
+ * promise resolves once the upstream stream closes.
+ */
+export async function streamChatMessage(
+  message: string,
+  options: StreamChatOptions
+): Promise<void> {
+  const parsed = chatRequestSchema.safeParse({ message });
+  if (!parsed.success) {
+    throw new ChatApiError(
+      parsed.error.issues[0]?.message ?? "Please write a message before sending."
+    );
+  }
+
+  // Aligned with the server-side 60s OpenAI timeout + 5s slack for the
+  // final network leg back to the browser.
+  const timeoutMs = options.timeoutMs ?? 65_000;
+  const timeoutController = new AbortController();
+  const combinedSignal = mergeAbortSignals(options.signal, timeoutController.signal);
+  const timeoutHandle = window.setTimeout(() => timeoutController.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(STREAMING_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+      signal: combinedSignal,
+    });
+
+    if (!response.ok) {
+      const details = (await tryReadErrorDetail(response)) ?? "Unexpected server response.";
+      throw new ChatApiError(details, response.status);
+    }
+
+    if (!response.body) {
+      throw new ChatApiError("The chat service did not return a response stream.");
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        const chunk = decoder.decode(value, { stream: true });
+        if (chunk.length > 0) {
+          options.onChunk(chunk);
+        }
+      }
+    }
+  } catch (error) {
+    if (error instanceof ChatApiError) {
+      throw error;
+    }
+    if (error instanceof DOMException && error.name === "AbortError") {
+      if (options.signal?.aborted) {
+        throw new ChatApiError("Request cancelled.");
+      }
+      throw new ChatApiError(
+        `The request timed out after ${Math.round(timeoutMs / 1000)} seconds.`
+      );
+    }
+    throw new ChatApiError("Unable to reach the chat service. Please try again in a moment.");
+  } finally {
+    window.clearTimeout(timeoutHandle);
+  }
+}
+
 async function tryReadErrorDetail(response: Response): Promise<string | null> {
   try {
-    const json = (await response.json()) as { detail?: unknown };
-    if (typeof json.detail === "string" && json.detail.trim().length > 0) {
-      return json.detail;
-    }
-    return null;
+    const raw = await response.json();
+    const parsed = chatErrorResponseSchema.safeParse(raw);
+    return parsed.success ? parsed.data.detail : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
First of a two-part stacked-diff split of original PR 5 ("chat-shell decomposition + @theme tokens"). This is the **API + client layer foundation**. PR 5b will land the UI decomposition on top.

- **`app/api/chat/route.ts` (new, 193 lines)** — slim Next.js streaming proxy
  - Validates request body via `chatRequestSchema` (PR 4 zod)
  - Reads OpenAI key from `openai_api_key` httpOnly cookie
  - Calls `https://api.openai.com/v1/chat/completions` with `stream: true` + the Coldplay system prompt
  - Strips OpenAI SSE envelope server-side; pipes plain-text content deltas to the client
  - Validates upstream chunks via `openAiStreamChunkSchema`, passes through upstream errors via `openAiErrorResponseSchema`
  - Per-request `x-request-id` header for log correlation

- **`lib/chat-client.ts`** — back-compat extension
  - **NEW**: `streamChatMessage(message, { onChunk, signal, timeoutMs })` — POSTs to `/api/chat`, decodes UTF-8 chunks, delivers them via `onChunk`
  - **KEPT (@deprecated)**: `sendChatMessage` + `getBackendBaseUrl` — `chat-shell.tsx` still imports them; PR 5b switches the orchestrator over and these get removed there

- **`app/actions.ts`** — minimal viable cookie set
  - On successful key verification, sets `openai_api_key` as a 24h `httpOnly` cookie via Next's `cookies()`
  - Input validation moved from inline `isPlausibleOpenAiKey` to `verifyKeyInputSchema.safeParse` (PR 4 schemas integration)
  - `sameSite: lax`, raw key value — intentional intermediate state; PR 7 hardens with AES-256-GCM seal + `sameSite: strict`

## Why split this from the original PR 5
The original PR 5 plan listed "chat-shell decomposition + @theme tokens" but the stash implementation also required: streaming `chat-client.ts`, the `/api/chat` route, and several deps (`react-markdown`, `remark-gfm`). Bundling all of that into one PR violates single-feature-per-PR. Splitting into 5a (this PR — infrastructure) and 5b (UI) gives clean review boundaries, independent rollback, and `git bisect`-friendly layering.

## Out of scope (deferred to later PRs in the stack)
- **PR 5b**: chat-shell decomposition, `@theme` tokens, new component folders, hook extraction — consumes `streamChatMessage` from this PR
- **PR 7**: AES-256-GCM cookie seal/unseal, sameSite `strict`, `lib/session-crypto.ts`, same-origin guard on `/api/chat`
- **PR 8**: Upstash sliding-window rate limit on `/api/chat`, 8KB content-length cap, stream buffer cap
- **PR 9**: CSP nonce via `proxy.ts`, security headers, `/api/csp-report` endpoint

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0 against full tree)
- [ ] `pnpm install` resolves cleanly (no dep changes in this PR)
- [ ] Vercel preview turns green
- [ ] Manual: paste a valid `sk-...` key on the preview, click Verify — `openai_api_key` cookie appears in devtools, response is `ok: true`
- [ ] Manual: `curl -X POST https://<preview>/api/chat -H 'Content-Type: application/json' -H 'Cookie: openai_api_key=<test>' -d '{"message":"who is in Coldplay?"}'` — streams plain-text response with bolded **Chris Martin** etc.
- [ ] Backwards compatibility: existing `chat-shell.tsx` still compiles and `sendChatMessage` still works against the FastAPI backend in dev