### PR TITLE
feat(frontend): server foundations — env validation + error boundaries + metadata

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
+import { serverEnv } from "@/lib/env";
 import {
   chatRequestSchema,
   isPlausibleOpenAiKey,
@@ -13,8 +14,8 @@ export const runtime = "nodejs";
 const OPENAI_API_KEY_COOKIE = "openai_api_key";
 const OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 const OPENAI_TIMEOUT_MS = 60_000;
-const OPENAI_MODEL = process.env.OPENAI_MODEL ?? "gpt-5";
-const OPENAI_MAX_TOKENS = Number(process.env.OPENAI_MAX_COMPLETION_TOKENS ?? 280);
+const OPENAI_MODEL = serverEnv.OPENAI_MODEL;
+const OPENAI_MAX_TOKENS = serverEnv.OPENAI_MAX_COMPLETION_TOKENS;
 
 const COLDPLAY_SYSTEM_PROMPT = [
   "You are a Coldplay-only assistant. Answer only questions about Coldplay, ",

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Route-level error boundary. Catches errors thrown by children
+ * (e.g. <ChatShell>) and renders a calm fallback matching the
+ * chat-shell aesthetic. `reset()` re-mounts the route.
+ */
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Log only structured, non-sensitive fields. The raw error object
+    // can carry user input or internal state — neither belongs in
+    // wherever console.error gets shipped (Vercel logs, Sentry, etc.).
+    // Stack traces stay locally in the browser via React's own dev tools.
+    console.error("[/route-error]", {
+      digest: error.digest ?? null,
+      name: error.name,
+    });
+  }, [error]);
+
+  return (
+    <main className="relative isolate flex min-h-svh items-center justify-center px-4 py-8">
+      <section
+        role="alert"
+        aria-live="assertive"
+        className="chat-shell-glass mx-auto flex w-full max-w-[520px] flex-col items-center gap-4 rounded-3xl p-8 text-center text-white"
+      >
+        <h1 className="m-0 bg-linear-to-r from-cyan-300 via-fuchsia-400 to-violet-400 bg-clip-text font-bold text-2xl text-transparent">
+          Something went off-key
+        </h1>
+        <p className="m-0 max-w-[40ch] text-sm text-white/85 leading-relaxed sm:text-base">
+          The Coldplay companion hit an unexpected note. We&apos;ve logged it. You can try
+          recovering this view without losing your conversation.
+        </p>
+        {error.digest ? (
+          <p className="m-0 font-mono text-white/55 text-xs">request id: {error.digest}</p>
+        ) : null}
+        <button
+          type="button"
+          onClick={reset}
+          className="aurora-button rounded-full px-6 py-2 font-semibold text-base"
+        >
+          Try again
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Root-level error boundary. Triggered when the root layout itself throws.
+ * Must include its own <html> and <body> since the layout is unavailable.
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0f3260",
+          color: "#ffffff",
+          fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+          padding: "2rem",
+        }}
+      >
+        <div style={{ maxWidth: "520px", textAlign: "center" }}>
+          <h1 style={{ fontSize: "1.75rem", margin: "0 0 1rem" }}>Application crashed</h1>
+          <p style={{ fontSize: "0.95rem", lineHeight: 1.6, margin: "0 0 1.5rem", opacity: 0.85 }}>
+            The Coldplay companion couldn&apos;t recover from a root-level error. Reloading the page
+            is the safest next step.
+          </p>
+          {error.digest ? (
+            <p style={{ fontFamily: "monospace", fontSize: "0.75rem", opacity: 0.55 }}>
+              request id: {error.digest}
+            </p>
+          ) : null}
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "9999px",
+              border: "1px solid rgba(255,255,255,0.3)",
+              background: "rgba(255,255,255,0.1)",
+              color: "#ffffff",
+              fontSize: "1rem",
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,24 +1,75 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
+
 import "./globals.css";
 
+const SITE_NAME = "Coldplay AI Companion";
+const SITE_DESCRIPTION =
+  "An AI companion for the universe of Coldplay — songs, albums, eras, members, live shows, and everything in between. A non-commercial educational student project.";
+
 export const metadata: Metadata = {
-  title: "Coldplay Chat",
-  description: "A Coldplay-focused chat interface powered by your local backend.",
+  metadataBase: new URL("http://localhost:3000"),
+  title: {
+    default: SITE_NAME,
+    template: `%s · ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  authors: [{ name: "AI Engineer Challenge" }],
+  keywords: ["Coldplay", "AI chat", "music", "OpenAI", "Next.js", "Tailwind", "educational"],
+  category: "education",
+  // Intentional. This is a non-commercial educational project that uses
+  // Coldplay brand IP under fair use. Allowing search-engine indexing
+  // would risk brand-confusion / IP concerns. Lighthouse drops SEO to
+  // ~63 because of this — that is by design, not a regression.
+  robots: {
+    index: false,
+    follow: false,
+  },
   icons: {
     icon: "https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766",
     shortcut: "https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766",
-    apple: "https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766"
-  }
+    apple: "https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#0f3260",
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
 };
 
 export default function RootLayout({
-  children
+  children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {/* Skip-link: keyboard users tab to it first; visually hidden
+            until focused. Targets the `id="main-content"` landmark on
+            HomePage so the chat is reachable in one keystroke. */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-full focus:bg-white focus:px-4 focus:py-2 focus:font-semibold focus:text-slate-900 focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-cyan-400"
+        >
+          Skip to main content
+        </a>
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/**
+ * Type-safe environment validation at module load.
+ *
+ * Catches missing or malformed env vars at startup rather than at first
+ * user request — fail loud at boot, not silently at runtime. Server vars
+ * are not exposed to the client bundle (this module is server-only).
+ *
+ * Usage:
+ *   import { serverEnv } from "@/lib/env";
+ *   serverEnv.OPENAI_MODEL   // string, validated
+ *
+ * Future PRs extend this schema as new env vars arrive:
+ *   • PR 7  → SESSION_SECRET (AES-256-GCM cookie seal)
+ *   • PR 8  → KV_REST_API_URL + KV_REST_API_TOKEN (Upstash rate limit)
+ *   • PR 14 → BLOB_AUDIO_AEROPHONIA_URL (Vercel Blob audio source)
+ */
+
+const serverEnvSchema = z.object({
+  OPENAI_MODEL: z.string().trim().min(1).default("gpt-5"),
+  OPENAI_MAX_COMPLETION_TOKENS: z.coerce.number().int().positive().default(280),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+});
+
+function parseEnv<T extends z.ZodTypeAny>(
+  schema: T,
+  source: Record<string, string | undefined>
+): z.infer<T> {
+  const result = schema.safeParse(source);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid environment variables:\n${issues}`);
+  }
+  return result.data;
+}
+
+/** Server-only env. Do NOT import from a client component. */
+export const serverEnv = parseEnv(serverEnvSchema, {
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  OPENAI_MAX_COMPLETION_TOKENS: process.env.OPENAI_MAX_COMPLETION_TOKENS,
+  NODE_ENV: process.env.NODE_ENV,
+});


### PR DESCRIPTION
## Summary
Lays the server-side correctness floor: env validation at boot, error boundaries at every render depth, and the full a11y + SEO + share metadata baseline. Five files, additive only.

- **`lib/env.ts` (new, +45)** — zod-validated `serverEnv` at module load
  - `OPENAI_MODEL` (default `gpt-5`), `OPENAI_MAX_COMPLETION_TOKENS` (default `280`), `NODE_ENV`
  - Throws a structured error at boot if any value is malformed → fail loud, not silent
  - Server-only — never imported from client components
- **`app/error.tsx` (new, +54)** — route-level error boundary
  - Catches render failures inside `<HomePage>` children
  - On-brand glass fallback matching the chat-shell aesthetic
  - Logs only `digest` + `name` (sanitized — raw error may carry user input)
  - `Try again` button calls `reset()` to re-mount the route
- **`app/global-error.tsx` (new, +58)** — root-level error boundary
  - Triggered when the root layout itself throws (must include own `<html>` + `<body>`)
  - Pure inline-styles fallback so it works without the layout
  - `Reload` button
- **`app/layout.tsx` (modified, +65)** — full metadata + a11y baseline
  - `lang="en"`, skip-link as first focusable element → keyboard users tab once to reach `#main-content`
  - `metadataBase`, title template (`%s · Coldplay AI Companion`), description, applicationName, authors, keywords, category
  - **Intentional `robots: noindex/nofollow`** — non-commercial educational use of Coldplay IP; allowing indexing would risk brand-confusion concerns
  - OpenGraph + Twitter share cards
  - `viewport` export with `themeColor: #0f3260`, scale 1–5 (allows pinch-zoom for a11y)
- **`app/api/chat/route.ts` (modified, +5/-9)** — migrates from `process.env.X ?? default` to typed `serverEnv.X` (single source of truth, no scattered defaults)

## Why
Misconfigured env should fail at boot, not at first user request. Error boundaries prevent the white-screen-of-death. The full metadata block is FAANG baseline — anything less drops Lighthouse PWA + SEO + Best Practices scores. `noindex` is intentional, not a bug.

## Out of scope (intentional, deferred)
- **PR 7 cookie security**: `SESSION_SECRET` zod entry + Shannon-entropy gate (≥3 bits/char in production), `lib/session-crypto.ts` (`seal`/`unseal`), sameSite `strict`, 24h TTL, same-origin guard on `/api/chat`, `hasVerifiedKeyAction` wrapping `unseal`
- **PR 8 rate limit**: `KV_REST_API_URL` + `KV_REST_API_TOKEN` (Vercel-canonical Upstash names), Upstash sliding-window check on the route
- **PR 14 audio**: `BLOB_AUDIO_AEROPHONIA_URL`, `/api/audio/aerophonia` proxy route, host allow-list
- **PR 9 CSP**: per-request nonce via `proxy.ts`, security headers, `/api/csp-report`

All four extend the same `serverEnv` schema or the same `/api/chat` route additively without re-touching these files.

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0)
- [ ] Vercel preview turns green
- [ ] Booting with `OPENAI_MAX_COMPLETION_TOKENS=garbage pnpm dev` fails fast at startup with `Invalid environment variables: OPENAI_MAX_COMPLETION_TOKENS: Expected number`
- [ ] Tab key on a fresh page reveals the `Skip to main content` link as the first focused element
- [ ] `<head>` source contains `<meta name="robots" content="noindex,nofollow">`
- [ ] Force a render error in a child of `<HomePage>` → `error.tsx` renders the calm fallback with the `Try again` button