### PR TITLE
feat(frontend): cookie security — AES-256-GCM seal + sameSite strict + origin guard

### DIFF
--- a/frontend/app/actions.ts
+++ b/frontend/app/actions.ts
@@ -2,7 +2,8 @@
 
 import { cookies } from "next/headers";
 
-import { verifyKeyInputSchema } from "@/lib/schemas";
+import { isPlausibleOpenAiKey, verifyKeyInputSchema } from "@/lib/schemas";
+import { seal, unseal } from "@/lib/session-crypto";
 
 export interface VerifyKeyResult {
   ok: boolean;
@@ -11,9 +12,7 @@ export interface VerifyKeyResult {
 
 const OPENAI_API_KEY_COOKIE = "openai_api_key";
 // 24h: short enough to bound key-disclosure blast radius, long enough that
-// a normal day's session survives without re-verification. PR 7 (cookie
-// security) wraps the raw value with AES-256-GCM seal and tightens
-// sameSite to "strict".
+// a normal day's session survives without re-verification.
 const SESSION_TTL_SECONDS = 60 * 60 * 24;
 
 export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyResult> {
@@ -37,14 +36,15 @@ export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyRe
 
     if (response.ok) {
       const cookieStore = await cookies();
-      // Raw key for now — PR 7 wraps with AES-256-GCM seal so cookie
-      // disclosure (logs, browser-ext, OS-level inspection) only yields
-      // an opaque blob without SESSION_SECRET. Same-site policy also
-      // tightens to "strict" in PR 7.
-      cookieStore.set(OPENAI_API_KEY_COOKIE, key, {
+      // Seal the key with AES-256-GCM before it ever lands in the cookie
+      // jar. Cookie disclosure (logs, browser-ext, OS-level inspection)
+      // yields only an opaque blob without SESSION_SECRET.
+      cookieStore.set(OPENAI_API_KEY_COOKIE, seal(key), {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
+        // strict (not lax): cross-site navigation must NOT carry this
+        // key cookie. App is single-origin; strict has zero UX cost.
+        sameSite: "strict",
         path: "/",
         maxAge: SESSION_TTL_SECONDS,
       });
@@ -79,9 +79,23 @@ export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyRe
 }
 
 /**
+ * Server-side "is the user verified" check. Used by client components that
+ * need to re-confirm session validity (e.g. after a long idle). Unseals the
+ * cookie and verifies the plaintext key shape — fails closed on any tamper.
+ */
+export async function hasVerifiedKeyAction(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const sealed = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
+  if (typeof sealed !== "string" || sealed.length === 0) {
+    return false;
+  }
+  const decrypted = unseal(sealed);
+  return decrypted !== null && isPlausibleOpenAiKey(decrypted);
+}
+
+/**
  * Powers the Disconnect button in `ConnectionStatusCard`: clears the
- * key cookie server-side so the next request is unverified. Hardened in
- * PR 7 with sealed-cookie deletion semantics + structured logging.
+ * sealed key cookie server-side so the next request is unverified.
  */
 export async function clearVerifiedKeyAction(): Promise<void> {
   const cookieStore = await cookies();

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
   openAiErrorResponseSchema,
   openAiStreamChunkSchema,
 } from "@/lib/schemas";
+import { unseal } from "@/lib/session-crypto";
 
 export const runtime = "nodejs";
 
@@ -34,8 +35,39 @@ const COLDPLAY_SYSTEM_PROMPT = [
   "- Do not use headings (#) inline — keep responses flowing prose + lists.",
 ].join("");
 
+/**
+ * Same-origin guard (CSRF defense-in-depth). Server Actions get free CSRF
+ * protection from Next.js; route handlers do not. Reject any POST whose
+ * Origin header doesn't match the request URL host. Cookies might travel
+ * cross-site even with sameSite=strict on browsers that don't honor it
+ * correctly; this is belt + suspenders.
+ *
+ * Missing Origin (server-to-server probe / curl without --header Origin)
+ * also fails closed — legitimate browsers always include Origin on POST.
+ */
+function isSameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) {
+    return false;
+  }
+  try {
+    return new URL(origin).host === new URL(request.url).host;
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID();
+
+  // Cheapest guard first — drops obvious cross-site abuse before we
+  // touch JSON parsing, cookie storage, or the upstream OpenAI fetch.
+  if (!isSameOrigin(request)) {
+    return NextResponse.json(
+      { detail: "Cross-origin requests are not permitted." },
+      { status: 403, headers: { "x-request-id": requestId } }
+    );
+  }
 
   let body: unknown;
   try {
@@ -55,12 +87,13 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // Raw key cookie — PR 7 wraps this with AES-256-GCM unseal here, adds
-  // a same-origin guard above this read, and PR 8 layers a sliding-window
-  // rate limit before any of this work happens.
+  // Cookie is AES-256-GCM sealed. unseal() returns null on any tamper or
+  // wrong-key failure — fail closed, never trust a partial decrypt.
+  // PR 8 layers a sliding-window rate limit before this work happens.
   const cookieStore = await cookies();
-  const keyCookie = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
-  if (!keyCookie || !isPlausibleOpenAiKey(keyCookie)) {
+  const sealed = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
+  const apiKey = typeof sealed === "string" ? unseal(sealed) : null;
+  if (apiKey === null || !isPlausibleOpenAiKey(apiKey)) {
     return NextResponse.json(
       { detail: "OpenAI key not verified. Please re-enter your key." },
       { status: 401, headers: { "x-request-id": requestId } }
@@ -76,7 +109,7 @@ export async function POST(request: Request): Promise<Response> {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${keyCookie}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
         model: OPENAI_MODEL,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,17 +6,17 @@ import { LoveIsTheOnlyAnswer } from "@/components/decoration/love-is-the-only-an
 import { DisclaimerFooter } from "@/components/layout/disclaimer-footer";
 import { Hero } from "@/components/layout/hero";
 import { isPlausibleOpenAiKey } from "@/lib/schemas";
+import { unseal } from "@/lib/session-crypto";
 
 const OPENAI_API_KEY_COOKIE = "openai_api_key";
 
 export default async function HomePage() {
-  // Raw cookie value — PR 7 (cookie security) wraps this with AES-256-GCM
-  // seal/unseal so the cookie holds an opaque blob instead of the plaintext
-  // key. For now we just sanity-check shape with the shared schema.
+  // Cookie is AES-256-GCM sealed. unseal() returns null on any tamper or
+  // wrong-key failure, which we treat as "unverified" — fail closed.
   const cookieStore = await cookies();
-  const rawCookie = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
-  const initialIsApiKeyVerified =
-    typeof rawCookie === "string" && isPlausibleOpenAiKey(rawCookie);
+  const sealedKey = cookieStore.get(OPENAI_API_KEY_COOKIE)?.value;
+  const apiKey = typeof sealedKey === "string" ? unseal(sealedKey) : null;
+  const initialIsApiKeyVerified = apiKey !== null && isPlausibleOpenAiKey(apiKey);
 
   return (
     <main

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -9,18 +9,49 @@ import { z } from "zod";
  *
  * Usage:
  *   import { serverEnv } from "@/lib/env";
- *   serverEnv.OPENAI_MODEL   // string, validated
+ *   serverEnv.OPENAI_MODEL    // string, validated
+ *   serverEnv.SESSION_SECRET  // string, length + entropy enforced
  *
  * Future PRs extend this schema as new env vars arrive:
- *   • PR 7  → SESSION_SECRET (AES-256-GCM cookie seal)
  *   • PR 8  → KV_REST_API_URL + KV_REST_API_TOKEN (Upstash rate limit)
  *   • PR 14 → BLOB_AUDIO_AEROPHONIA_URL (Vercel Blob audio source)
  */
+
+const SESSION_SECRET_MIN_CHARS_NON_PROD = 32;
+const SESSION_SECRET_MIN_CHARS_PROD = 48;
+const SESSION_SECRET_MIN_ENTROPY_PROD = 3.0;
+
+/**
+ * Shannon entropy in bits per character. A truly-random base64 string
+ * sits around 5.5–6.0; lazy "password123" patterns sit below 3. The
+ * production gate rejects anything below 3 bits/char so SESSION_SECRET
+ * can't be hand-typed in a moment of weakness.
+ */
+function shannonEntropyBitsPerChar(input: string): number {
+  if (input.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const ch of input) {
+    counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  }
+  let bits = 0;
+  for (const count of counts.values()) {
+    const p = count / input.length;
+    bits -= p * Math.log2(p);
+  }
+  return bits;
+}
 
 const serverEnvSchema = z.object({
   OPENAI_MODEL: z.string().trim().min(1).default("gpt-5"),
   OPENAI_MAX_COMPLETION_TOKENS: z.coerce.number().int().positive().default(280),
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  // Used by lib/session-crypto.ts to AES-256-GCM-seal the OpenAI key cookie.
+  // Generate with: openssl rand -base64 48
+  //   • Non-prod: >= 32 chars (so tests / dev can pin a fixed value)
+  //   • Production: >= 48 chars AND >= 3 bits/char Shannon entropy
+  // The length-by-environment + entropy check are enforced post-parse so
+  // they can read NODE_ENV (which is itself parsed by this same schema).
+  SESSION_SECRET: z.string(),
 });
 
 function parseEnv<T extends z.ZodTypeAny>(
@@ -42,4 +73,25 @@ export const serverEnv = parseEnv(serverEnvSchema, {
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   OPENAI_MAX_COMPLETION_TOKENS: process.env.OPENAI_MAX_COMPLETION_TOKENS,
   NODE_ENV: process.env.NODE_ENV,
+  SESSION_SECRET: process.env.SESSION_SECRET,
 });
+
+// Environment-aware SESSION_SECRET strength gate. Runs at module load —
+// failure here throws before any handler can serve a request.
+const sessionSecretMinChars =
+  serverEnv.NODE_ENV === "production"
+    ? SESSION_SECRET_MIN_CHARS_PROD
+    : SESSION_SECRET_MIN_CHARS_NON_PROD;
+if (serverEnv.SESSION_SECRET.length < sessionSecretMinChars) {
+  throw new Error(
+    `SESSION_SECRET must be at least ${sessionSecretMinChars} characters in ${serverEnv.NODE_ENV}. Generate with: openssl rand -base64 48`
+  );
+}
+if (serverEnv.NODE_ENV === "production") {
+  const entropy = shannonEntropyBitsPerChar(serverEnv.SESSION_SECRET);
+  if (entropy < SESSION_SECRET_MIN_ENTROPY_PROD) {
+    throw new Error(
+      `SESSION_SECRET entropy is ${entropy.toFixed(2)} bits/char; production requires >= ${SESSION_SECRET_MIN_ENTROPY_PROD}. Use 'openssl rand -base64 48' — do not hand-type the value.`
+    );
+  }
+}

--- a/frontend/lib/session-crypto.ts
+++ b/frontend/lib/session-crypto.ts
@@ -1,0 +1,77 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+import { serverEnv } from "@/lib/env";
+
+/**
+ * Authenticated symmetric encryption for cookie values (AES-256-GCM).
+ *
+ * Threat model: the raw OpenAI API key must never appear in any log, header
+ * dump, browser cookie jar, or extension's `cookies` query. Wrapping it in
+ * an AES-GCM seal means even full cookie-jar disclosure yields only an
+ * opaque blob without the SESSION_SECRET — which only the server runtime
+ * holds (Vercel env var, never shipped to the client bundle).
+ *
+ * Why AES-256-GCM:
+ *  - Authenticated encryption (auth tag detects tampering)
+ *  - NIST-approved, AEAD by construction (no separate MAC needed)
+ *  - Native to Node's `crypto` (zero dependencies)
+ *
+ * Format: `b64url(iv).b64url(ciphertext).b64url(authTag)`. Dot is safe in
+ * cookie values (RFC 6265 cookie-octet). base64url avoids URL-encoding
+ * surprises if a future code path log-rounds-trips the value.
+ */
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTE_LENGTH = 12;
+const SEPARATOR = ".";
+
+let cachedKey: Buffer | null = null;
+
+function getKey(): Buffer {
+  if (cachedKey === null) {
+    // SHA-256 collapses any-length secret to a stable 32-byte AES-256 key.
+    // SESSION_SECRET is already required to be ≥32 chars (env.ts), giving
+    // ≥256 bits of input entropy — a single SHA-256 is appropriate here
+    // (HKDF would add ceremony without changing the security ceiling).
+    cachedKey = createHash("sha256").update(serverEnv.SESSION_SECRET).digest();
+  }
+  return cachedKey;
+}
+
+export function seal(plaintext: string): string {
+  const iv = randomBytes(IV_BYTE_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, getKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64url"),
+    ciphertext.toString("base64url"),
+    authTag.toString("base64url"),
+  ].join(SEPARATOR);
+}
+
+/**
+ * Returns null on ANY decryption failure: malformed input, wrong secret,
+ * tampered ciphertext, mismatched auth tag. Callers MUST handle null as
+ * "no valid session" and never trust a partial decrypt.
+ */
+export function unseal(sealedValue: string): string | null {
+  const parts = sealedValue.split(SEPARATOR);
+  if (parts.length !== 3) return null;
+  const [ivPart, ciphertextPart, authTagPart] = parts;
+  if (!ivPart || !ciphertextPart || !authTagPart) return null;
+
+  try {
+    const iv = Buffer.from(ivPart, "base64url");
+    const ciphertext = Buffer.from(ciphertextPart, "base64url");
+    const authTag = Buffer.from(authTagPart, "base64url");
+    if (iv.length !== IV_BYTE_LENGTH) return null;
+
+    const decipher = createDecipheriv(ALGORITHM, getKey(), iv);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plaintext.toString("utf8");
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
The most security-critical PR in the stack. Wraps the user's OpenAI key with authenticated encryption before it ever lands in the cookie jar, tightens cross-site cookie policy, and adds a same-origin guard on `/api/chat`.

- **`lib/session-crypto.ts` (new, +77)** — AES-256-GCM `seal` / `unseal`
  - Native `node:crypto`, zero deps
  - 12-byte random IV per seal, 16-byte auth tag, base64url-encoded
  - Format: `b64url(iv).b64url(ciphertext).b64url(authTag)` — dot is RFC 6265 cookie-safe
  - `unseal()` returns `null` on ANY decryption failure (malformed input, wrong secret, tampered bytes, mismatched auth tag) — fail closed, never a partial decrypt
- **`lib/env.ts`** — adds `SESSION_SECRET` to the schema + a post-parse strength gate
  - Dev/test: ≥ 32 chars (so tests / dev can pin a fixed value)
  - Production: ≥ 48 chars AND ≥ 3 bits/char Shannon entropy (rejects hand-typed `password123` patterns at boot)
- **`app/actions.ts`** — seals + tightens
  - `cookieStore.set(... seal(key) ...)` — cookie value is now opaque blob, not the raw `sk-...`
  - `sameSite: lax → strict` — no legitimate cross-site reason to send this cookie (app is single-origin; zero UX cost)
  - **New `hasVerifiedKeyAction`** — server-side "is the user verified" check that unseals + validates
- **`app/page.tsx`** — server-side `unseal()` of the cookie + `isPlausibleOpenAiKey` shape check before flipping `initialIsApiKeyVerified` true
- **`app/api/chat/route.ts`**
  - **`isSameOrigin` guard** — cheapest check, runs first; rejects cross-origin POSTs with `403` before touching JSON parse / cookie / upstream
  - Cookie read switches from raw value to `unseal()` + shape check

## Why each layer
| Threat | Mitigation |
|---|---|
| Cookie disclosure (logs, browser-ext, OS-level dumps) | `seal()` — yields only an opaque blob without `SESSION_SECRET` |
| Lazy `SESSION_SECRET` value (`aaaaaa...`) | Boot-time entropy gate (rejects < 3 bits/char in prod) |
| Cross-site cookie leak on misbehaving browsers | `sameSite: strict` — cookie never travels on cross-site nav |
| CSRF on the route handler (no Next built-in protection) | Origin-header guard, drops mismatched Origin + missing Origin with `403` |
| Tampered cookie bypassing auth | `unseal()` fail-closed + shape revalidation |

## Required setup (Vercel + local)
This PR adds `SESSION_SECRET` to the required env var set. The app will refuse to boot without it.

- **Local dev**: `printf 'SESSION_SECRET=%s\n' "$(openssl rand -base64 48)" >> .env.local`
- **Vercel** (Production + Preview): already configured in earlier setup. Verify in Dashboard → Project → Settings → Environment Variables.

## Out of scope (intentional, deferred)
- **PR 8** — Upstash sliding-window rate limit on `/api/chat`, 8KB content-length cap, stream buffer cap
- **PR 9** — CSP per-request nonce via `proxy.ts`, security headers (HSTS, X-Frame-Options, etc.), `/api/csp-report` endpoint

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally with `SESSION_SECRET` set: `tsc --noEmit` exit 0)
- [ ] Vercel preview turns green
- [ ] `SESSION_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa NODE_ENV=production pnpm start` — fails with entropy error
- [ ] `curl -X POST https://<preview>/api/chat -H 'Origin: https://evil.example.com' -H 'Content-Type: application/json' -d '{"message":"hi"}'` → `403`
- [ ] `curl -X POST https://<preview>/api/chat -H 'Content-Type: application/json' -d '{"message":"hi"}'` (no Origin) → `403`
- [ ] Browser: paste key → verify → DevTools Application → Cookies: `openai_api_key` value is an opaque `iv.ciphertext.authTag` triplet (NOT a raw `sk-...`)
- [ ] Manually mutate a single character of the sealed cookie in DevTools → reload → returned to locked state (unseal failed)
- [ ] Squash-and-merge once Vercel is green