### PR TITLE
feat(frontend): per-IP rate limit + content-length cap + stream buffer cap

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { serverEnv } from "@/lib/env";
+import { checkRateLimit, getClientKey } from "@/lib/rate-limit";
 import {
   chatRequestSchema,
   isPlausibleOpenAiKey,
@@ -17,6 +18,14 @@ const OPENAI_CHAT_COMPLETIONS_ENDPOINT = "https://api.openai.com/v1/chat/complet
 const OPENAI_TIMEOUT_MS = 60_000;
 const OPENAI_MODEL = serverEnv.OPENAI_MODEL;
 const OPENAI_MAX_TOKENS = serverEnv.OPENAI_MAX_COMPLETION_TOKENS;
+// 8KB body cap. chatRequestSchema caps `message` at 4000 chars; a well-formed
+// payload is well under this. A larger Content-Length is by definition either
+// junk wrapping or an attempt to exhaust the JSON parser before validation.
+const MAX_REQUEST_BODY_BYTES = 8 * 1024;
+// 64KB upstream SSE buffer cap. A misbehaving upstream that never emits a
+// newline could accumulate unbounded memory in the chunk buffer; this cap
+// tears the stream down before that happens.
+const MAX_SSE_BUFFER_BYTES = 64 * 1024;
 
 const COLDPLAY_SYSTEM_PROMPT = [
   "You are a Coldplay-only assistant. Answer only questions about Coldplay, ",
@@ -67,6 +76,39 @@ export async function POST(request: Request): Promise<Response> {
       { detail: "Cross-origin requests are not permitted." },
       { status: 403, headers: { "x-request-id": requestId } }
     );
+  }
+
+  // Per-IP sliding-window rate limit runs before any auth/parse work —
+  // each chat request becomes a paid OpenAI call downstream, so the
+  // cheapest place to shed abusive floods is here.
+  const rateLimit = await checkRateLimit(getClientKey(request));
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      {
+        detail: `Too many requests. Please wait ${rateLimit.retryAfterSec}s and try again.`,
+      },
+      {
+        status: 429,
+        headers: {
+          "x-request-id": requestId,
+          "Retry-After": String(rateLimit.retryAfterSec),
+          "X-RateLimit-Remaining": String(rateLimit.remaining),
+          "X-RateLimit-Reset": String(rateLimit.resetAt),
+        },
+      }
+    );
+  }
+
+  // Content-Length pre-check: cheap reject before we buffer the body.
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_REQUEST_BODY_BYTES) {
+      return NextResponse.json(
+        { detail: "Request body too large." },
+        { status: 413, headers: { "x-request-id": requestId } }
+      );
+    }
   }
 
   let body: unknown;
@@ -183,6 +225,12 @@ export async function POST(request: Request): Promise<Response> {
           }
 
           buffer += decoder.decode(value, { stream: true });
+          if (buffer.length > MAX_SSE_BUFFER_BYTES) {
+            // Defense against an upstream that streams without newlines —
+            // unbounded buffer growth would leak memory. Tear it down.
+            controller.error(new Error("Upstream SSE buffer exceeded cap"));
+            return;
+          }
           const lines = buffer.split("\n");
           buffer = lines.pop() ?? "";
 

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -13,7 +13,6 @@ import { z } from "zod";
  *   serverEnv.SESSION_SECRET  // string, length + entropy enforced
  *
  * Future PRs extend this schema as new env vars arrive:
- *   • PR 8  → KV_REST_API_URL + KV_REST_API_TOKEN (Upstash rate limit)
  *   • PR 14 → BLOB_AUDIO_AEROPHONIA_URL (Vercel Blob audio source)
  */
 
@@ -52,6 +51,12 @@ const serverEnvSchema = z.object({
   // The length-by-environment + entropy check are enforced post-parse so
   // they can read NODE_ENV (which is itself parsed by this same schema).
   SESSION_SECRET: z.string(),
+  // Optional. When both are present, /api/chat rate-limits via Upstash
+  // sliding window. Vercel's Upstash Marketplace integration sets these
+  // canonical names when no custom prefix is configured. Absence triggers
+  // the per-instance in-memory fallback with a loud production warning.
+  KV_REST_API_URL: z.string().url().optional(),
+  KV_REST_API_TOKEN: z.string().min(1).optional(),
 });
 
 function parseEnv<T extends z.ZodTypeAny>(
@@ -74,6 +79,8 @@ export const serverEnv = parseEnv(serverEnvSchema, {
   OPENAI_MAX_COMPLETION_TOKENS: process.env.OPENAI_MAX_COMPLETION_TOKENS,
   NODE_ENV: process.env.NODE_ENV,
   SESSION_SECRET: process.env.SESSION_SECRET,
+  KV_REST_API_URL: process.env.KV_REST_API_URL,
+  KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN,
 });
 
 // Environment-aware SESSION_SECRET strength gate. Runs at module load —

--- a/frontend/lib/rate-limit.ts
+++ b/frontend/lib/rate-limit.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-key sliding-window rate limiter.
+ *
+ * Why this exists: even with httpOnly + SameSite=Strict + AES-256-GCM
+ * seal on the session cookie, the chat endpoint forwards every request
+ * as a paid OpenAI call downstream. Without throttling, a runaway client
+ * (retry loop, abuse, leaked cookie) drains the user's quota in seconds.
+ *
+ * Backend selection at module load:
+ *   • If KV_REST_API_URL + KV_REST_API_TOKEN are set (Vercel's canonical
+ *     names from the Upstash Marketplace integration when no custom
+ *     prefix is configured): use @upstash/ratelimit sliding-window
+ *     against Upstash Redis. This is the only correct option on Vercel
+ *     serverless — state is shared across function instances.
+ *   • Otherwise: fall back to an in-memory Map (per-Node-instance).
+ *     Suitable ONLY for local dev / single-instance deployments.
+ *
+ * A loud console.warn fires in production if the integration vars are
+ * missing, so the operator sees the gap in deploy logs.
+ *
+ * The call site in app/api/chat/route.ts just awaits a single
+ * checkRateLimit(key) — the backend choice is invisible to it.
+ */
+
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+import { serverEnv } from "@/lib/env";
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS_PER_WINDOW = 20;
+const CLEANUP_INTERVAL_MS = 5 * 60_000;
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  retryAfterSec: number;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Backend selection — done once at module load
+// ──────────────────────────────────────────────────────────────────────
+
+const upstashUrl = serverEnv.KV_REST_API_URL;
+const upstashToken = serverEnv.KV_REST_API_TOKEN;
+const hasUpstashCreds = upstashUrl !== undefined && upstashToken !== undefined;
+
+const upstashLimiter: Ratelimit | null = hasUpstashCreds
+  ? new Ratelimit({
+      redis: new Redis({ url: upstashUrl, token: upstashToken }),
+      limiter: Ratelimit.slidingWindow(MAX_REQUESTS_PER_WINDOW, `${WINDOW_MS} ms`),
+      analytics: false,
+      prefix: "coldplay-chat",
+    })
+  : null;
+
+if (!hasUpstashCreds && serverEnv.NODE_ENV === "production") {
+  // Loud, structured warning. Not an error — single-instance deployments
+  // still get rate limiting, just not distributed. Operators who care
+  // about correctness under autoscale will provision Upstash via the
+  // Vercel Marketplace integration (no custom prefix => KV_REST_API_*).
+  console.warn(
+    "[rate-limit] KV_REST_API_URL / KV_REST_API_TOKEN not set. " +
+      "Falling back to per-instance in-memory limiter — NOT safe for distributed deployments. " +
+      "Provision Upstash from Vercel → Marketplace to fix."
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// In-memory fallback
+// ──────────────────────────────────────────────────────────────────────
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+let lastCleanupAt = 0;
+
+function checkInMemory(key: string): RateLimitDecision {
+  pruneExpired();
+  const now = Date.now();
+  const existing = buckets.get(key);
+
+  if (existing === undefined || now >= existing.resetAt) {
+    const fresh: Bucket = { count: 1, resetAt: now + WINDOW_MS };
+    buckets.set(key, fresh);
+    return {
+      allowed: true,
+      remaining: MAX_REQUESTS_PER_WINDOW - 1,
+      resetAt: fresh.resetAt,
+      retryAfterSec: 0,
+    };
+  }
+
+  if (existing.count >= MAX_REQUESTS_PER_WINDOW) {
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt: existing.resetAt,
+      retryAfterSec: Math.ceil((existing.resetAt - now) / 1000),
+    };
+  }
+
+  existing.count += 1;
+  return {
+    allowed: true,
+    remaining: MAX_REQUESTS_PER_WINDOW - existing.count,
+    resetAt: existing.resetAt,
+    retryAfterSec: 0,
+  };
+}
+
+function pruneExpired(): void {
+  const now = Date.now();
+  if (now - lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+  for (const [key, bucket] of buckets.entries()) {
+    if (now >= bucket.resetAt) buckets.delete(key);
+  }
+  lastCleanupAt = now;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────
+
+export async function checkRateLimit(key: string): Promise<RateLimitDecision> {
+  if (upstashLimiter !== null) {
+    const result = await upstashLimiter.limit(key);
+    const now = Date.now();
+    return {
+      allowed: result.success,
+      remaining: result.remaining,
+      resetAt: result.reset,
+      retryAfterSec: result.success ? 0 : Math.max(0, Math.ceil((result.reset - now) / 1000)),
+    };
+  }
+  return checkInMemory(key);
+}
+
+/**
+ * Extract a stable per-client key. On Vercel, x-forwarded-for is the
+ * first hop set by the edge network; the first IP in the list is the
+ * client. Falls back to x-real-ip then a generic bucket (worst case:
+ * shared limit across unknown clients).
+ */
+export function getClientKey(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp.trim();
+  return "unknown-client";
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/postcss": "^4.3.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1017,6 +1023,18 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   '@vercel/backends@0.6.0':
     resolution: {integrity: sha512-Fw+9s72dMowyL4HNl4IYCbk0ubvfDDXpgaPENNx49+k248LU9LoLjDOek7gTiAfwiiQK3RViN3327ZLCe0GF/A==}
@@ -2433,6 +2451,9 @@ packages:
   uid-promise@1.0.0:
     resolution: {integrity: sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -3177,6 +3198,19 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/backends@0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -5013,6 +5047,8 @@ snapshots:
   typescript@6.0.3: {}
 
   uid-promise@1.0.0: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary
Layers three throttling defenses on `/api/chat` — each one runs cheapest-first so abuse never gets close to the paid OpenAI call.

- **`lib/rate-limit.ts` (new, +158)** — sliding-window per-IP, 20 req/min
  - **Backend selection at module load**:
    - `KV_REST_API_URL` + `KV_REST_API_TOKEN` present → `@upstash/ratelimit` against Upstash Redis (only correct option on Vercel serverless — state shared across function instances)
    - Otherwise → per-Node-instance `Map` (in-memory; dev / single-instance only)
  - Production deployments without Upstash creds emit a loud structured `console.warn` so the gap shows up in deploy logs
  - `getClientKey()` parses `x-forwarded-for` → `x-real-ip` → `"unknown-client"` fallback
- **`lib/env.ts`** — adds `KV_REST_API_URL` (`.url().optional()`) and `KV_REST_API_TOKEN` (`.min(1).optional()`). Both optional — the in-memory fallback degrades gracefully.
- **`app/api/chat/route.ts`** — three new defenses, ordered cheapest-first:
  1. **`checkRateLimit()`** after origin guard, before parse / cookie / OpenAI. Returns `429` with `Retry-After`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
  2. **`Content-Length` pre-check** — payloads > 8KB rejected with `413` before buffering. `chatRequestSchema` caps `message` at 4000 chars so well-formed payloads sit well under this.
  3. **Upstream SSE buffer cap** of 64KB — defends against a malicious/misbehaving upstream that streams without newlines and would otherwise leak memory unboundedly. Tears the stream down with a controller error if exceeded.
- **deps**: `@upstash/ratelimit` `^2.0.8`, `@upstash/redis` `^1.38.0` (server-only, not in client bundle)

## Why `KV_REST_API_*` and not `UPSTASH_REDIS_REST_*`
Vercel's Upstash Marketplace integration sets `KV_REST_API_URL` + `KV_REST_API_TOKEN` natively **when no custom prefix is configured**. Reading the canonical names means **the integration is the single source of truth** — no duplicate secrets, no aliasing, no drift. The user already provisioned Upstash via the Marketplace earlier in the project, so these env vars are already live on Vercel (Production + Preview).

## Required env on Vercel (already configured)
- `KV_REST_API_URL` — set automatically by the Upstash Marketplace integration
- `KV_REST_API_TOKEN` — set automatically by the Upstash Marketplace integration

If either is missing on Preview, the rate-limit falls back to in-memory and you'll see the `[rate-limit] KV_REST_API_URL / KV_REST_API_TOKEN not set` warning in Vercel function logs.

## Out of scope (intentional, deferred)
- **PR 9** — CSP per-request nonce via `proxy.ts`, security headers in `next.config.ts`, `/api/csp-report` endpoint

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally with `SESSION_SECRET` set: `tsc --noEmit` exit 0)
- [ ] Vercel preview turns green
- [ ] `for i in {1..25}; do curl -X POST https://<preview>/api/chat -H 'Origin: https://<preview>' -H 'Content-Type: application/json' -H 'Cookie: openai_api_key=<sealed>' -d '{"message":"hi"}'; done` — 21st+ request returns `429` with `Retry-After`
- [ ] `curl` a `Content-Length: 99999` header → `413`
- [ ] Vercel function logs for a fresh production deploy do NOT show the `[rate-limit] ... falling back to per-instance` warning (confirms Upstash creds are picked up)