### PR TITLE
feat(frontend): strict CSP with per-request nonce + security headers + report endpoint

### DIFF
--- a/frontend/app/api/csp-report/route.ts
+++ b/frontend/app/api/csp-report/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+
+/**
+ * CSP violation report sink. Browsers POST here when the Content-Security
+ * -Policy header is violated (referenced via `report-to` + `Reporting-
+ * Endpoints` in `proxy.ts`).
+ *
+ * Behavior:
+ *  - Caps body size to 8KB (CSP reports are tiny; anything larger is junk)
+ *  - Logs a structured one-liner (timestamp, ip, truncated report)
+ *  - Always returns 204 No Content — reports are best-effort and we
+ *    must not block the browser if the sink is slow
+ *  - No rate limit applied: a flood of CSP reports usually indicates a
+ *    legitimate browser-extension issue, not abuse, and 204 responses
+ *    are cheap. If sustained abuse appears, swap to in-memory limiter.
+ *
+ * What gets reported:
+ *  - Modern browsers (CSP3 / Reporting API): JSON array of report
+ *    objects with `csp-report` shape
+ *  - Older browsers (`report-uri` fallback): `application/csp-report`
+ *    JSON body
+ *
+ * We don't parse the report shape — just truncate + log. Production
+ * deployments should swap `console.warn` for a SIEM/Sentry hook.
+ */
+
+const MAX_REPORT_BYTES = 8 * 1024;
+
+export async function POST(request: Request): Promise<Response> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(length) && length > MAX_REPORT_BYTES) {
+      return new NextResponse(null, { status: 204 });
+    }
+  }
+
+  try {
+    const raw = await request.text();
+    const truncated = raw.slice(0, MAX_REPORT_BYTES);
+    // Structured log — never logs the raw error object or user input.
+    console.warn(
+      JSON.stringify({
+        type: "csp-violation",
+        ts: new Date().toISOString(),
+        ua: request.headers.get("user-agent") ?? null,
+        report: truncated,
+      })
+    );
+  } catch {
+    // Best-effort. Swallow malformed reports rather than 500.
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,68 @@
 import type { NextConfig } from "next";
 
+/**
+ * Static security headers applied to every response. Per-request headers
+ * that need entropy (CSP nonce) live in `proxy.ts` — these are the values
+ * that never change per request.
+ */
+const securityHeaders = [
+  // 2-year HSTS + preload — once a browser sees this, it refuses
+  // plaintext to the apex + all subdomains for two years.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  // Defense against clickjacking. CSP `frame-ancestors 'none'` is the
+  // modern equivalent; this is the legacy fallback for older browsers.
+  { key: "X-Frame-Options", value: "DENY" },
+  // Block MIME-type sniffing — defeats the classic
+  // "upload an image that browsers execute as JS" trick.
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Send origin only on cross-site requests, full URL same-site.
+  // Matches modern UA defaults; explicit so a default flip can't surprise us.
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Deny every powerful API by default. fullscreen=(self) is the only
+  // allowance — useful for embedded video. Add explicit allowances back
+  // when a future feature actually needs them.
+  {
+    key: "Permissions-Policy",
+    value: [
+      "accelerometer=()",
+      "camera=()",
+      "geolocation=()",
+      "gyroscope=()",
+      "magnetometer=()",
+      "microphone=()",
+      "payment=()",
+      "usb=()",
+      "interest-cohort=()",
+      "browsing-topics=()",
+      "fullscreen=(self)",
+    ].join(", "),
+  },
+  // Cross-Origin-Opener-Policy: opens a fresh browsing-context group, so
+  // window.opener / window.parent attacks from popups can't reach back.
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  // Cross-Origin-Resource-Policy: same-origin only. Prevents hot-linking
+  // + Spectre-style cross-origin reads.
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+  // Don't pre-resolve DNS for outgoing links — privacy hardening.
+  { key: "X-DNS-Prefetch-Control", value: "off" },
+];
+
 const nextConfig: NextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  // Don't ship the default `X-Powered-By: Next.js` header — small recon
+  // win for an attacker, zero functional value.
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,0 +1,95 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Edge proxy (Next.js 16+ file convention — replaces the deprecated
+ * `middleware.ts`). Emits a per-request CSP nonce and the strict CSP
+ * header. Next.js auto-applies the nonce to its own hydration scripts
+ * when a CSP with `nonce-*` is present.
+ *
+ * Why proxy (not next.config.ts) for CSP: nonces MUST be unique
+ * per response. `next.config.ts` `headers()` are static.
+ *
+ * Other security headers (HSTS, X-Frame-Options, etc.) live in
+ * `next.config.ts` since they don't change per request.
+ */
+
+export function proxy(request: NextRequest): NextResponse {
+  // 16 random bytes → 22-char base64 nonce. Per-request, never reused.
+  const nonce = Buffer.from(crypto.getRandomValues(new Uint8Array(16))).toString("base64");
+
+  // CSP violation reports go back to the same origin. Built per-request
+  // so the report endpoint always matches the deployment domain (works
+  // for prod, preview, local-dev without env-var coupling).
+  const requestUrl = new URL(request.url);
+  const reportingEndpoint = `${requestUrl.protocol}//${requestUrl.host}/api/csp-report`;
+
+  // strict-dynamic: trust scripts loaded by a nonced script, not by URL.
+  //   `'unsafe-inline'`, `https:`, and `'self'` are IGNORED by CSP3
+  //   browsers when `'strict-dynamic'` is present. They exist as
+  //   fallbacks so CSP1/CSP2 browsers (which don't understand
+  //   `'strict-dynamic'`) still get a functioning policy. Modern
+  //   security posture is unchanged.
+  // 'unsafe-eval' is needed only for Next.js dev hot-reload; gated to dev.
+  const scriptSrc =
+    process.env.NODE_ENV === "production"
+      ? `'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' https:`
+      : `'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' 'unsafe-eval' https:`;
+
+  // style-src 'unsafe-inline': Tailwind v4 emits style attributes on
+  // hydrated nodes; nonce-based style-src is not yet supported by
+  // Tailwind's runtime. This is the documented Next.js + Tailwind v4
+  // CSP recipe. img-src https: covers the Coldplay CDN backgrounds.
+  //
+  // Reporting: `report-to` is the CSP3 way (modern browsers, paired
+  // with the `Reporting-Endpoints` response header below).
+  // `report-uri` is the deprecated fallback for browsers that don't
+  // support the Reporting API yet (Safari < 16, Firefox).
+  const cspParts = [
+    "default-src 'self'",
+    `script-src ${scriptSrc}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' https: data: blob:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "media-src 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "upgrade-insecure-requests",
+    "report-to csp-endpoint",
+    `report-uri ${reportingEndpoint}`,
+  ];
+  const cspHeader = cspParts.join("; ");
+
+  // Pass nonce to the React tree via request header so server
+  // components can read it via `headers()` from `next/headers`.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("content-security-policy", cspHeader);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", cspHeader);
+  // Reporting API: names the endpoint referenced by `report-to` above.
+  // Absolute URL required by the spec.
+  response.headers.set("Reporting-Endpoints", `csp-endpoint="${reportingEndpoint}"`);
+  return response;
+}
+
+export const config = {
+  // Skip static assets and Next.js internals — they're served with their
+  // own headers and don't need a per-request nonce. Apply CSP to every
+  // dynamic route (pages + API).
+  matcher: [
+    {
+      source:
+        "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:webp|png|jpg|jpeg|svg|gif|ico|js|css|mp3|wav|woff2?)).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
Hardens the response surface with the full FAANG-baseline security header set plus a strict, per-request-nonce CSP.

- **`proxy.ts` (new, 95 lines)** — Next.js 16 file convention (replaces deprecated `middleware.ts`)
  - Emits a fresh 16-byte base64 nonce on every dynamic request
  - Strict CSP header references the nonce via `script-src 'nonce-XXX' 'strict-dynamic'`
  - `'strict-dynamic'` makes CSP3 browsers trust scripts loaded by a nonced script and IGNORE the `'unsafe-inline'` + `https:` fallbacks (those exist only for CSP1/CSP2 browser support — modern security posture unchanged)
  - `'unsafe-eval'` is gated to `NODE_ENV !== "production"` (Next.js dev hot-reload needs it)
  - `style-src 'unsafe-inline'` is the documented Next.js + Tailwind v4 CSP recipe
  - `frame-ancestors 'none'` + `form-action 'self'` + `object-src 'none'` + `base-uri 'self'` complete the policy
  - `report-to csp-endpoint` (CSP3 Reporting API) + `report-uri` (legacy fallback) both point at `/api/csp-report`
  - Matcher skips `_next/static`, `_next/image`, and static asset extensions — saves a header generation per static request
- **`next.config.ts`** — static security headers (don't change per request)
  - **HSTS** `max-age=63072000; includeSubDomains; preload` (2 years)
  - **X-Frame-Options** `DENY` (legacy clickjacking defense; CSP `frame-ancestors 'none'` is the modern equivalent)
  - **X-Content-Type-Options** `nosniff`
  - **Referrer-Policy** `strict-origin-when-cross-origin`
  - **Permissions-Policy** — full deny by default, `fullscreen=(self)` is the only allowance
  - **Cross-Origin-Opener-Policy** `same-origin` (drops `window.opener` attacks)
  - **Cross-Origin-Resource-Policy** `same-origin` (anti-hotlink + Spectre)
  - **X-DNS-Prefetch-Control** `off`
  - **`poweredByHeader: false`** — drops `X-Powered-By: Next.js`
- **`app/api/csp-report/route.ts` (new, 55 lines)** — CSP violation sink
  - 8KB body cap (reports are tiny; anything bigger is junk)
  - Structured one-line log (`timestamp` + `UA` + truncated body, never raw error objects)
  - Always returns `204` — best-effort, never blocks the browser

## Why proxy.ts and not middleware.ts
Next.js 16 deprecated `middleware.ts` in favor of `proxy.ts` (file-convention rename + clearer semantics). Same edge-runtime model, same matcher syntax — the only difference is the filename.

## Why split nonce CSP from static headers
Per-request headers (CSP nonce) must regenerate every response. `next.config.ts` `headers()` are computed once at build time — they cannot vary per request. Splitting keeps each in its right place: `proxy.ts` for entropy-bearing, `next.config.ts` for static.

## Out of scope (intentional, deferred)
- **PR 10** — `vercel.json` (region pin, function memory + maxDuration), `public/robots.txt`
- **PR 11** — Playwright + vitest test infrastructure
- **PR 13** — responsive polish + dead code cleanup
- **PR 14** — layered audio (orchestrator + Vercel Blob route + toggle)
- **PR 15** — README rewrite

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0)
- [ ] Vercel preview turns green
- [ ] `curl -I https://<preview>/` — confirms all security headers + CSP with a unique `nonce-*` per call
- [ ] Two `curl -I` calls show different nonces
- [ ] DevTools console on the locked + verified pages: NO CSP violations
- [ ] Trigger a violation (e.g. paste an inline `<script>` via DevTools) — `console.warn` `csp-violation` log appears in Vercel function logs
- [ ] SecurityHeaders.com scan returns A+ once deployed