### PR TITLE
chore(frontend): vercel.json (region + function caps) + robots.txt disallow

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,9 @@
+# Defense-in-depth alongside <meta name="robots" content="noindex,nofollow">
+# in app/layout.tsx. This file blocks crawlers that ignore meta directives.
+#
+# Intentional: this is a non-commercial educational student project that
+# uses Coldplay brand IP under fair use. Indexing it would risk
+# brand-confusion / IP concerns.
+
+User-agent: *
+Disallow: /

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["iad1"],
+  "functions": {
+    "app/api/chat/route.ts": {
+      "maxDuration": 60,
+      "memory": 1024
+    },
+    "app/api/csp-report/route.ts": {
+      "maxDuration": 5,
+      "memory": 256
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Two-file deployment-config drop. Small but important — production latency, cost ceiling, and crawler block all in one PR.

- **`vercel.json` (new, 14 lines)**
  - `"regions": ["iad1"]` (Washington DC East) — pins the function region to match the Upstash Redis region provisioned via the Marketplace integration. Keeps the rate-limit hop on-net so it doesn't add cross-region latency to every chat request.
  - Per-function memory + `maxDuration` caps:
    - `/api/chat` → 60s / 1024MB (OpenAI streaming budget)
    - `/api/csp-report` → 5s / 256MB (fire-and-forget log sink, no upstream calls)
  - Why caps matter: keeps a runaway function from running 15 minutes at max memory on the free/hobby plan and torching the bill. The chat route's 60s aligns with the in-route `OPENAI_TIMEOUT_MS`.
- **`public/robots.txt` (new, 9 lines)** — `User-agent: * \n Disallow: /`
  - Defense-in-depth alongside the intentional `<meta name="robots" content="noindex,nofollow">` in `app/layout.tsx`. Some crawlers ignore meta directives; this is the second wall.
  - Same reason in both places: non-commercial educational use of Coldplay IP under fair use.

## Out of scope (intentional, deferred)
- **PR 14** — `/api/audio/aerophonia` function entry (30s / 256MB) lands alongside the audio orchestrator + Vercel Blob URL env var
- **PR 11** — test infrastructure (Playwright on port 3010, vitest setup)
- **PR 13** — responsive polish + dead code cleanup
- **PR 15** — README rewrite

## Test plan
- [ ] Vercel preview turns green
- [ ] `curl https://<preview>/robots.txt` returns the disallow body with 200
- [ ] After merge, Vercel function logs show region `iad1` (Washington DC) on cold starts
- [ ] Function cold-start memory matches the configured cap (visible in Vercel Function metrics dashboard)