### PR TITLE
test(frontend): playwright on port 3010 + vitest setup + first specs

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -55,6 +55,10 @@ const nextConfig: NextConfig = {
   // Don't ship the default `X-Powered-By: Next.js` header — small recon
   // win for an attacker, zero functional value.
   poweredByHeader: false,
+  // Honor NEXT_DIST_DIR so the Playwright test runner can build into
+  // `.next-test/` (isolated from a developer's `pnpm dev` writing to
+  // `.next/` on port 3000). Set by `tests/global-setup.ts`.
+  distDir: process.env.NEXT_DIST_DIR ?? ".next",
   async headers() {
     return [
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,10 @@
     "format": "biome format",
     "format:fix": "biome format --write",
     "typecheck": "tsc --noEmit",
-    "audit": "pnpm audit --prod --audit-level=high"
+    "audit": "pnpm audit --prod --audit-level=high",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",
@@ -35,10 +38,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
+    "@playwright/test": "^1.59.1",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "typescript": "latest",
-    "vercel": "latest"
+    "vercel": "latest",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import { TEST_BASE_URL, TEST_PORT, TEST_SESSION_SECRET } from "./tests/global-setup";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  fullyParallel: true,
+  reporter: "line",
+  globalSetup: "./tests/global-setup.ts",
+  use: {
+    baseURL: TEST_BASE_URL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    // Tests run against the production build, matching Vercel exactly
+    // and avoiding the `next dev` singleton lock (so a developer can
+    // keep `pnpm dev` running on 3000 while tests use 3010). The
+    // `.next-test` dist dir keeps test artifacts isolated from dev.
+    command: `pnpm exec next build && pnpm exec next start --hostname localhost --port ${TEST_PORT}`,
+    cwd: ".",
+    port: TEST_PORT,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    env: {
+      SESSION_SECRET: TEST_SESSION_SECRET,
+      NEXT_DIST_DIR: ".next-test",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.15
         version: 2.4.15
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: latest
         version: 25.6.2
@@ -78,6 +81,9 @@ importers:
       vercel:
         specifier: latest
         version: 54.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@edge-runtime/vm@3.2.0)(@types/node@25.6.2)(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0))
 
 packages:
 
@@ -596,6 +602,9 @@ packages:
   '@oxc-project/types@0.110.0':
     resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
 
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
   '@oxc-transform/binding-android-arm-eabi@0.111.0':
     resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -776,16 +785,34 @@ packages:
     resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
     engines: {node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0}
 
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.1':
@@ -794,17 +821,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
     resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
     resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
@@ -813,12 +859,40 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
@@ -827,6 +901,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -834,16 +915,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
     resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
     resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
@@ -851,11 +949,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
     resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
 
   '@rolldown/pluginutils@1.0.0-rc.1':
     resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
@@ -871,6 +978,9 @@ packages:
 
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -980,8 +1090,14 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1142,6 +1258,35 @@ packages:
   '@vercel/static-config@3.3.0':
     resolution: {integrity: sha512-GpS3tPwUeDJCkrKbMNtS2XLRFgfxTlN7YNUL+Bo23+fGolrDw6Oq79R3yvxTYgqRaJMGSEqC7iMw6mj6I5loxg==}
 
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1171,6 +1316,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -1262,6 +1411,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1319,6 +1472,9 @@ packages:
   convert-hrtime@3.0.0:
     resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
     engines: {node: '>=8'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@2.0.1:
     resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
@@ -1411,6 +1567,9 @@ packages:
   es-module-lexer@1.5.0:
     resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1448,6 +1607,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1470,6 +1632,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -1488,6 +1654,15 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -2055,6 +2230,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.3.3:
     resolution: {integrity: sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==}
 
@@ -2115,6 +2293,9 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -2236,6 +2417,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.0-rc.1:
     resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2283,6 +2469,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2322,12 +2511,18 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@0.3.0:
     resolution: {integrity: sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-to-array@2.3.0:
     resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
@@ -2397,8 +2592,23 @@ packages:
     resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
     engines: {node: '>=10'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2512,6 +2722,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.12:
+    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
 
@@ -2524,6 +2818,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -2909,6 +3208,8 @@ snapshots:
 
   '@oxc-project/types@0.110.0': {}
 
+  '@oxc-project/types@0.129.0': {}
+
   '@oxc-transform/binding-android-arm-eabi@0.111.0':
     optional: true
 
@@ -2977,7 +3278,6 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
-    optional: true
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -3012,34 +3312,77 @@ snapshots:
 
   '@renovatebot/pep440@4.2.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -3050,11 +3393,19 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-rc.1': {}
 
@@ -3065,6 +3416,8 @@ snapshots:
       picomatch: 4.0.4
 
   '@sinclair/typebox@0.25.24': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3155,9 +3508,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3517,6 +3877,47 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   abbrev@3.0.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
@@ -3539,6 +3940,8 @@ snapshots:
   arg@4.1.0: {}
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -3602,6 +4005,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3641,6 +4046,8 @@ snapshots:
   content-type@1.0.4: {}
 
   convert-hrtime@3.0.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@2.0.1: {}
 
@@ -3723,6 +4130,8 @@ snapshots:
 
   es-module-lexer@1.5.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3781,6 +4190,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -3818,6 +4231,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expect-type@1.3.0: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3839,6 +4254,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-uri-to-path@1.0.0: {}
 
@@ -4569,6 +4988,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  obug@2.1.1: {}
+
   once@1.3.3:
     dependencies:
       wrappy: 1.0.2
@@ -4658,6 +5079,8 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@2.0.3: {}
+
   pend@1.2.0: {}
 
   picocolors@1.0.0: {}
@@ -4668,15 +5091,13 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.59.1:
-    optional: true
+  playwright-core@1.59.1: {}
 
   playwright@1.59.1:
     dependencies:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   postcss@8.4.31:
     dependencies:
@@ -4802,6 +5223,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
+
   rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.110.0
@@ -4890,6 +5332,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.0.2: {}
@@ -4922,9 +5366,13 @@ snapshots:
     dependencies:
       cookie-es: 2.0.1
 
+  stackback@0.0.2: {}
+
   stat-mode@0.3.0: {}
 
   statuses@1.5.0: {}
+
+  std-env@4.1.0: {}
 
   stream-to-array@2.3.0:
     dependencies:
@@ -5008,7 +5456,18 @@ snapshots:
     dependencies:
       convert-hrtime: 3.0.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5157,6 +5616,48 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.2
+      esbuild: 0.27.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.21.0
+
+  vitest@4.1.6(@edge-runtime/vm@3.2.0)(@types/node@25.6.2)(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.12(@types/node@25.6.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 25.6.2
+    transitivePeerDependencies:
+      - msw
+
   web-vitals@0.2.4: {}
 
   webidl-conversions@3.0.1: {}
@@ -5169,6 +5670,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/frontend/responsive.config.ts
+++ b/frontend/responsive.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import { TEST_BASE_URL, TEST_PORT, TEST_SESSION_SECRET } from "./tests/global-setup";
+
+/**
+ * Dedicated config for the responsive visual audit. NOT part of
+ * `pnpm test:e2e`. Run on demand:
+ *
+ *   pnpm exec playwright test --config=responsive.config.ts
+ *
+ * Each project pins a representative breakpoint; the shared spec captures
+ * locked + verified screenshots at every project so the same UX surface
+ * can be visually diffed across iPhone SE → desktop.
+ */
+export default defineConfig({
+  testDir: "./tests/responsive",
+  timeout: 60_000,
+  reporter: "line",
+  fullyParallel: true,
+  globalSetup: "./tests/global-setup.ts",
+  use: {
+    baseURL: TEST_BASE_URL,
+    trace: "off",
+  },
+  webServer: {
+    command: `pnpm exec next build && pnpm exec next start --hostname localhost --port ${TEST_PORT}`,
+    cwd: ".",
+    port: TEST_PORT,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    env: {
+      SESSION_SECRET: TEST_SESSION_SECRET,
+      NEXT_DIST_DIR: ".next-test",
+    },
+  },
+  projects: [
+    {
+      name: "mobile-375",
+      use: { ...devices["iPhone SE"], viewport: { width: 375, height: 667 } },
+    },
+    {
+      name: "mobile-414",
+      use: { ...devices["iPhone 12 Pro Max"], viewport: { width: 414, height: 896 } },
+    },
+    {
+      name: "tablet-768",
+      use: { ...devices["iPad (gen 7)"], viewport: { width: 768, height: 1024 } },
+    },
+    {
+      name: "laptop-1024",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1024, height: 768 } },
+    },
+    {
+      name: "desktop-1440",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+    },
+  ],
+});

--- a/frontend/tests/actions.test.ts
+++ b/frontend/tests/actions.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cookiesMock } = vi.hoisted(() => ({
+  cookiesMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
+import { clearVerifiedKeyAction, hasVerifiedKeyAction, verifyOpenAiKeyAction } from "@/app/actions";
+import { seal, unseal } from "@/lib/session-crypto";
+
+function createCookieStore(initialValue?: string) {
+  return {
+    get: vi.fn((name: string) => {
+      if (name !== "openai_api_key") {
+        return undefined;
+      }
+      return initialValue ? { value: initialValue } : undefined;
+    }),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+describe("app/actions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cookiesMock.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("rejects obviously invalid key formats without network call", async () => {
+    const result = await verifyOpenAiKeyAction("not-a-key");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Invalid key format");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("stores key sealed (AES-256-GCM) in a secure httpOnly strict cookie on successful verification", async () => {
+    const cookieStore = createCookieStore();
+    cookiesMock.mockResolvedValue(cookieStore);
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+    const rawKey = "sk-valid-key-12345678901234567890";
+    const result = await verifyOpenAiKeyAction(rawKey);
+
+    expect(result.ok).toBe(true);
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      "openai_api_key",
+      expect.any(String),
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: "strict",
+        path: "/",
+      })
+    );
+    // Stored value must be the sealed form, never the raw key. Verifies
+    // the H2 invariant: raw key never lands in the cookie jar.
+    const storedValue = cookieStore.set.mock.calls[0]?.[1] as string;
+    expect(storedValue).not.toBe(rawKey);
+    expect(storedValue.split(".").length).toBe(3);
+    expect(unseal(storedValue)).toBe(rawKey);
+  });
+
+  it("returns explicit auth failure for revoked or invalid keys", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 401 }));
+
+    const result = await verifyOpenAiKeyAction("sk-invalid-key-12345678901234567890");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("invalid, revoked, or expired");
+  });
+
+  it("treats 429 as recognized key but warns about limits", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 429 }));
+
+    const result = await verifyOpenAiKeyAction("sk-rate-limited-key-123456789012345");
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("rate-limited");
+  });
+
+  it("returns network failure guidance when OpenAI cannot be reached", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("socket hang up"));
+
+    const result = await verifyOpenAiKeyAction("sk-network-fail-key-1234567890123456");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Could not reach OpenAI");
+  });
+
+  it("detects whether a plausible verified key cookie exists (sealed form)", async () => {
+    const cookieStore = createCookieStore(seal("sk-cookie-key-12345678901234567890"));
+    cookiesMock.mockResolvedValue(cookieStore);
+
+    await expect(hasVerifiedKeyAction()).resolves.toBe(true);
+  });
+
+  it("rejects a tampered or wrong-secret cookie value", async () => {
+    // Raw key with no seal → unseal() returns null → action says no key.
+    const cookieStore = createCookieStore("sk-cookie-key-not-sealed-no-good");
+    cookiesMock.mockResolvedValue(cookieStore);
+
+    await expect(hasVerifiedKeyAction()).resolves.toBe(false);
+  });
+
+  it("returns false when no verified key cookie exists", async () => {
+    const cookieStore = createCookieStore();
+    cookiesMock.mockResolvedValue(cookieStore);
+
+    await expect(hasVerifiedKeyAction()).resolves.toBe(false);
+  });
+
+  it("clears the verified key cookie", async () => {
+    const cookieStore = createCookieStore("sk-cookie-key-12345678901234567890");
+    cookiesMock.mockResolvedValue(cookieStore);
+
+    await clearVerifiedKeyAction();
+
+    expect(cookieStore.delete).toHaveBeenCalledWith("openai_api_key");
+  });
+});

--- a/frontend/tests/chat-route.test.ts
+++ b/frontend/tests/chat-route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cookiesMock } = vi.hoisted(() => ({
+  cookiesMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
+import { POST } from "@/app/api/chat/route";
+import { seal } from "@/lib/session-crypto";
+
+// Pre-seal the canonical test key once: the cookie store mock returns
+// this sealed blob, route handler unseals it, validates, proceeds.
+const SEALED_VALID_KEY = seal("sk-valid-cookie-1234567890123456789");
+
+function createCookieStore(value?: string) {
+  return {
+    get: vi.fn(() => (value ? { value } : undefined)),
+  };
+}
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request("http://localhost/api/chat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // Same-origin guard requires Origin to match request URL's
+      // protocol+host. Matches the URL above.
+      Origin: "http://localhost",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function createSseResponse(chunks: string[], status = 200): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("app/api/chat/route", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cookiesMock.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("req-fixed-123");
+  });
+
+  it("rejects cross-origin POSTs with 403 (CSRF defense-in-depth)", async () => {
+    const crossOriginRequest = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "https://evil.example.com",
+      },
+      body: JSON.stringify({ message: "Hello" }),
+    });
+
+    const response = await POST(crossOriginRequest);
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects requests with no Origin header (server-to-server probes)", async () => {
+    const originlessRequest = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Hello" }),
+    });
+
+    const response = await POST(originlessRequest);
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 401 when api key cookie is missing", async () => {
+    cookiesMock.mockResolvedValue(createCookieStore());
+
+    const response = await POST(makeJsonRequest({ message: "Hello" }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(401);
+    expect(payload.detail).toContain("missing or invalid");
+    expect(response.headers.get("x-request-id")).toBe("req-fixed-123");
+  });
+
+  it("returns 400 when message is empty", async () => {
+    cookiesMock.mockResolvedValue(createCookieStore(SEALED_VALID_KEY));
+
+    const response = await POST(makeJsonRequest({ message: "   " }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.detail).toContain("Message cannot be empty");
+  });
+
+  it("streams assistant text from OpenAI SSE chunks", async () => {
+    cookiesMock.mockResolvedValue(createCookieStore(SEALED_VALID_KEY));
+    vi.mocked(fetch).mockResolvedValue(
+      createSseResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+        "data: [DONE]\n\n",
+      ])
+    );
+
+    const response = await POST(makeJsonRequest({ message: "Say hello" }));
+    const responseText = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(responseText).toBe("Hello world");
+  });
+
+  it("maps OpenAI error payloads and propagates request id", async () => {
+    cookiesMock.mockResolvedValue(createCookieStore(SEALED_VALID_KEY));
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "The model is currently overloaded." } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const response = await POST(makeJsonRequest({ message: "Anything" }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(429);
+    expect(payload.detail).toContain("overloaded");
+    expect(payload.detail).toContain("request_id=req-fixed-123");
+  });
+
+  it("returns 504 when upstream request is aborted", async () => {
+    cookiesMock.mockResolvedValue(createCookieStore(SEALED_VALID_KEY));
+    vi.mocked(fetch).mockRejectedValue(new DOMException("aborted", "AbortError"));
+
+    const response = await POST(makeJsonRequest({ message: "Anything" }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(504);
+    expect(payload.detail).toContain("timed out");
+  });
+});

--- a/frontend/tests/e2e/session-persistence.spec.ts
+++ b/frontend/tests/e2e/session-persistence.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "@playwright/test";
+
+import { seal } from "@/lib/session-crypto";
+import { TEST_BASE_URL } from "../global-setup";
+
+const KEY_COOKIE_NAME = "openai_api_key";
+// Seal at test setup with the TEST_SESSION_SECRET that globalSetup pinned
+// into process.env. Server (started by Playwright with the same secret
+// via webServer.env) will unseal successfully.
+const KEY_COOKIE_VALUE = seal("sk-playwright-cookie-key-12345678901234567890");
+const CHAT_STATE_STORAGE_KEY = "coldplay_chat_ui_state_v1";
+const CHAT_SCROLL_STORAGE_KEY = "coldplay_chat_scroll_top_v1";
+
+test.beforeEach(async ({ context, page }) => {
+  await context.addCookies([
+    {
+      name: KEY_COOKIE_NAME,
+      value: KEY_COOKIE_VALUE,
+      url: TEST_BASE_URL,
+      httpOnly: true,
+      sameSite: "Strict",
+    },
+  ]);
+
+  await page.route("**/api/chat", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain; charset=utf-8",
+      body: "Playwright synthetic response.",
+    });
+  });
+});
+
+test("refresh restores messages, draft input, and conversation scroll", async ({ page }) => {
+  await page.goto("/");
+
+  await page.evaluate(
+    ({ stateKey, scrollKey }) => {
+      const baseTime = Date.now() - 80_000;
+      const messages = Array.from({ length: 80 }, (_, index) => ({
+        id: `msg-${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `Persisted message ${index} — long content to ensure overflow and scroll behavior.`,
+        createdAt: baseTime + index * 1000,
+      }));
+
+      window.sessionStorage.setItem(
+        stateKey,
+        JSON.stringify({
+          messages,
+          inputValue: "Draft should survive refresh",
+        })
+      );
+      window.sessionStorage.setItem(scrollKey, "420");
+    },
+    { stateKey: CHAT_STATE_STORAGE_KEY, scrollKey: CHAT_SCROLL_STORAGE_KEY }
+  );
+
+  await page.reload();
+
+  await expect(page.getByText("Persisted message 79")).toHaveCount(1);
+  await expect(page.locator("#chat-input")).toHaveValue("Draft should survive refresh");
+
+  const conversation = page.locator('section[aria-label="Conversation"]');
+  await expect
+    .poll(async () => {
+      return conversation.evaluate((node) => Math.round(node.scrollTop));
+    })
+    .toBeGreaterThan(300);
+
+  await conversation.evaluate((node) => {
+    node.scrollTop = 560;
+    node.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+
+  await page.reload();
+
+  await expect
+    .poll(async () => {
+      return conversation.evaluate((node) => Math.round(node.scrollTop));
+    })
+    .toBeGreaterThan(500);
+});
+
+test("disconnect clears cookie-backed session state and client persistence", async ({ page }) => {
+  await page.goto("/");
+
+  await page.evaluate(
+    ({ stateKey, scrollKey }) => {
+      const now = Date.now();
+      window.sessionStorage.setItem(
+        stateKey,
+        JSON.stringify({
+          // Welcome-injection wipes assistant-only state and replays the
+          // typewriter; a real conversation always has a user turn, so we
+          // seed both roles to mirror production shape.
+          messages: [
+            {
+              id: "persisted-user-1",
+              role: "user",
+              content: "User turn so welcome-injection leaves state alone.",
+              createdAt: now - 1000,
+            },
+            {
+              id: "persisted-1",
+              role: "assistant",
+              content: "Persisted text to clear.",
+              createdAt: now,
+            },
+          ],
+          inputValue: "Draft to clear.",
+        })
+      );
+      window.sessionStorage.setItem(scrollKey, "200");
+    },
+    { stateKey: CHAT_STATE_STORAGE_KEY, scrollKey: CHAT_SCROLL_STORAGE_KEY }
+  );
+
+  await page.reload();
+  await expect(page.getByText("Persisted text to clear.")).toHaveCount(1);
+
+  await page.getByRole("button", { name: "Disconnect verified key" }).click();
+
+  await expect(
+    page.getByText("Secure key session cleared. Please verify a key to continue.")
+  ).toBeVisible();
+  await expect(page.getByRole("region", { name: "OpenAI key verification" })).toBeVisible();
+
+  await page.reload();
+
+  await expect(page.getByText("Persisted text to clear.")).toHaveCount(0);
+  // Locked state has no chat composer; confirming absence is the new shape
+  // of the "draft did not survive" assertion.
+  await expect(page.locator("#chat-input")).toHaveCount(0);
+
+  const storageState = await page.evaluate(
+    ({ stateKey, scrollKey }) => ({
+      chat: window.sessionStorage.getItem(stateKey),
+      scroll: window.sessionStorage.getItem(scrollKey),
+    }),
+    { stateKey: CHAT_STATE_STORAGE_KEY, scrollKey: CHAT_SCROLL_STORAGE_KEY }
+  );
+
+  if (storageState.chat !== null) {
+    expect(JSON.parse(storageState.chat)).toEqual({
+      messages: [],
+      inputValue: "",
+    });
+  }
+  expect(storageState.scroll).toBeNull();
+});

--- a/frontend/tests/global-setup.ts
+++ b/frontend/tests/global-setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Playwright global setup. Runs once before any test, in the same Node
+ * process as the test runner.
+ *
+ * Purpose: guarantee a deterministic SESSION_SECRET shared between
+ *  (a) the dev server Playwright will spawn (via webServer.env), and
+ *  (b) the test runner itself (so test code that calls `seal()` from
+ *      `@/lib/session-crypto` derives the same AES key as the server).
+ *
+ * Port 3010 is dedicated to tests so the developer's own `pnpm dev` on
+ * 3000 is never interfered with. Both the dev server and the test
+ * server can run side-by-side.
+ *
+ * The session secret is for tests only. Never reuse it in any deployed
+ * environment — it is intentionally hardcoded and visible.
+ */
+export const TEST_SESSION_SECRET =
+  "playwright-test-only-DO-NOT-USE-IN-ANY-DEPLOYED-ENVIRONMENT-32+chars";
+
+export const TEST_PORT = 3010;
+export const TEST_BASE_URL = `http://localhost:${TEST_PORT}`;
+
+export default async function globalSetup(): Promise<void> {
+  process.env.SESSION_SECRET = TEST_SESSION_SECRET;
+}

--- a/frontend/tests/responsive/responsive-audit.spec.ts
+++ b/frontend/tests/responsive/responsive-audit.spec.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { seal } from "@/lib/session-crypto";
+import { TEST_BASE_URL } from "../global-setup";
+
+/**
+ * Cross-breakpoint visual audit. Captures locked + verified states at the
+ * pinned viewport for the running project (see responsive.config.ts).
+ *
+ * Output: tests/responsive/screenshots/{projectName}-{state}.png
+ */
+
+const KEY_COOKIE_NAME = "openai_api_key";
+const KEY_COOKIE_VALUE = seal("sk-responsive-cookie-key-12345678901234567890");
+const SCREENSHOT_DIR = path.join(__dirname, "screenshots");
+
+test.describe("responsive audit", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/chat", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain; charset=utf-8",
+        body: "Synthetic assistant reply.",
+      });
+    });
+  });
+
+  test("locked + verified frames", async ({ context, page }, testInfo) => {
+    const projectName = testInfo.project.name;
+
+    // ── Locked state ─────────────────────────────────────────────────────
+    await page.goto("/");
+    await expect(page.getByRole("region", { name: "OpenAI key verification" })).toBeVisible();
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${projectName}-01-locked.png`),
+      fullPage: true,
+    });
+
+    // ── Verified state (welcome) ─────────────────────────────────────────
+    await context.addCookies([
+      {
+        name: KEY_COOKIE_NAME,
+        value: KEY_COOKIE_VALUE,
+        url: TEST_BASE_URL,
+        httpOnly: true,
+        sameSite: "Strict",
+      },
+    ]);
+    await page.reload();
+    await expect(page.locator("#chat-input")).toBeVisible();
+    // Welcome typewriter is ~2.2s; allow margin.
+    await page.waitForTimeout(2800);
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, `${projectName}-02-verified.png`),
+      fullPage: true,
+    });
+  });
+});

--- a/frontend/tests/vitest-setup.ts
+++ b/frontend/tests/vitest-setup.ts
@@ -1,0 +1,7 @@
+/**
+ * Vitest global setup. Sets a deterministic SESSION_SECRET before any
+ * test file imports `@/lib/env` (which throws at module load if missing).
+ * Mirrors `tests/global-setup.ts` for Playwright. Hardcoded test secret
+ * — never reuse in any deployed environment.
+ */
+process.env.SESSION_SECRET = "vitest-only-DO-NOT-USE-IN-ANY-DEPLOYED-ENVIRONMENT-32+chars";

--- a/frontend/tests/walkthrough/walkthrough.spec.ts
+++ b/frontend/tests/walkthrough/walkthrough.spec.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { seal } from "@/lib/session-crypto";
+import { TEST_BASE_URL } from "../global-setup";
+
+/**
+ * Manual visual-walkthrough spec. NOT part of the default e2e suite
+ * (lives outside `tests/e2e/`). Run explicitly with:
+ *
+ *   pnpm exec playwright test tests/walkthrough/walkthrough.spec.ts
+ *
+ * Captures full-page screenshots at every UX milestone so a human (or a
+ * multimodal agent) can visually verify the post-WS4/WS5 chat flow:
+ *   locked (empty) → locked (key typed) → chat (welcome) → chat (sent) →
+ *   chat (assistant reply) → locked (after disconnect)
+ */
+
+const KEY_COOKIE_NAME = "openai_api_key";
+const KEY_COOKIE_VALUE = seal("sk-walkthrough-cookie-key-12345678901234567890");
+const SCREENSHOT_DIR = path.join(__dirname, "screenshots");
+
+const ASSISTANT_REPLY =
+  "Coldplay's recent work centers on Music of the Spheres (2021) — an interconnected, cosmically themed cycle — and the ongoing Moon Music continuation. Their live show is also pushing sustainable touring with kinetic floors and recycled materials.";
+
+test.describe("chat-shell visual walkthrough", () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept all chat traffic with a deterministic synthetic reply so
+    // we never depend on a real OPENAI_API_KEY or upstream latency.
+    await page.route("**/api/chat", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain; charset=utf-8",
+        body: ASSISTANT_REPLY,
+      });
+    });
+  });
+
+  test("locked → verified → conversation → disconnect", async ({ context, page }) => {
+    // ── 01. Locked, empty ────────────────────────────────────────────────
+    await page.goto("/");
+    await expect(page.getByRole("region", { name: "OpenAI key verification" })).toBeVisible();
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "01-locked-empty.png"),
+      fullPage: true,
+    });
+
+    // ── 02. Locked, key typed ────────────────────────────────────────────
+    await page.locator("#openai-key").fill("sk-walkthrough-typed-1234567890abcdef");
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "02-locked-with-key.png"),
+      fullPage: true,
+    });
+
+    // ── 03. Verified state (skip server verify; inject cookie + reload) ──
+    // The verify path calls OpenAI server-side, which we cannot mock from
+    // the browser. Injecting the cookie + reload lands us in the verified
+    // state with the same code path the cookie-restoration flow uses.
+    await context.addCookies([
+      {
+        name: KEY_COOKIE_NAME,
+        value: KEY_COOKIE_VALUE,
+        url: TEST_BASE_URL,
+        httpOnly: true,
+        sameSite: "Strict",
+      },
+    ]);
+    await page.reload();
+
+    // Welcome typewriter runs ~2.2s; allow margin before snapping.
+    await expect(page.locator("#chat-input")).toBeVisible();
+    await page.waitForTimeout(2800);
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "03-chat-welcome.png"),
+      fullPage: true,
+    });
+
+    // ── 04. Composer filled, pre-send ────────────────────────────────────
+    await page.locator("#chat-input").fill("Tell me about Coldplay's recent work.");
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "04-composer-filled.png"),
+      fullPage: true,
+    });
+
+    // ── 05. After send, assistant rendered ───────────────────────────────
+    await page.locator("#chat-input").press("Enter");
+    await expect(page.getByText("Coldplay's recent work centers on", { exact: false })).toBeVisible(
+      { timeout: 10_000 }
+    );
+    // Brief settle for any tail animation.
+    await page.waitForTimeout(600);
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "05-conversation.png"),
+      fullPage: true,
+    });
+
+    // ── 06. After disconnect ─────────────────────────────────────────────
+    await page.getByRole("button", { name: "Disconnect verified key" }).click();
+    await expect(
+      page.getByText("Secure key session cleared. Please verify a key to continue.")
+    ).toBeVisible();
+    // Allow panel-swap to settle.
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "06-locked-after-disconnect.png"),
+      fullPage: true,
+    });
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,7 +28,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-test/types/**/*.ts",
+    ".next-test/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    // Runs before any test module is imported. Sets SESSION_SECRET so
+    // `lib/env.ts` validation passes when test code transitively imports
+    // server modules.
+    setupFiles: ["./tests/vitest-setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
+});

--- a/frontend/walkthrough.config.ts
+++ b/frontend/walkthrough.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import { TEST_BASE_URL, TEST_PORT, TEST_SESSION_SECRET } from "./tests/global-setup";
+
+/**
+ * Dedicated config for the visual walkthrough spec. Keeps screenshot
+ * capture out of `pnpm test:e2e` (which is meant to be fast and stable),
+ * while letting us run it on demand:
+ *
+ *   pnpm exec playwright test --config=walkthrough.config.ts
+ */
+export default defineConfig({
+  testDir: "./tests/walkthrough",
+  timeout: 60_000,
+  reporter: "line",
+  globalSetup: "./tests/global-setup.ts",
+  use: {
+    baseURL: TEST_BASE_URL,
+    viewport: { width: 1440, height: 900 },
+    trace: "off",
+  },
+  webServer: {
+    command: `pnpm exec next build && pnpm exec next start --hostname localhost --port ${TEST_PORT}`,
+    cwd: ".",
+    port: TEST_PORT,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    env: {
+      SESSION_SECRET: TEST_SESSION_SECRET,
+      NEXT_DIST_DIR: ".next-test",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
Lays the test infrastructure foundation. All tests target a production build (matching Vercel exactly), on a port decoupled from the dev server, with full env-var isolation.

- **`playwright.config.ts` (new)** — runs against `next start` on port **3010** (so `pnpm dev` on 3000 stays untouched). webServer builds via `NEXT_DIST_DIR=.next-test pnpm exec next build && pnpm exec next start --port 3010` and injects `TEST_SESSION_SECRET`. Reuses an existing server if already running.
- **`vitest.config.ts` (new)** — node environment, `tests/**/*.test.ts`, setupFiles pin env vars before module load so `lib/env.ts` validation succeeds. `@/*` alias mirrors tsconfig.
- **`tests/global-setup.ts`** — TEST_PORT (3010), TEST_BASE_URL, TEST_SESSION_SECRET constants exported so playwright + vitest stay in sync.
- **`tests/vitest-setup.ts`** — pins SESSION_SECRET before any module loads, so transitive `lib/env.ts` imports validate against the test secret.
- **`next.config.ts`** — adds `distDir: process.env.NEXT_DIST_DIR ?? ".next"` so the playwright build can write to `.next-test/` (isolated from a developer's local `.next/`).
- **`tsconfig.json`** — adds `.next-test/types/**/*.ts` paths so Next.js's generated types resolve for the test build.
- **Specs (foundation only — coverage expands in follow-up PRs)**:
  - `tests/actions.test.ts` — `verify` / `clear` / `has-verified` key with the `next/headers` cookies mocked via `vi.hoisted`
  - `tests/chat-route.test.ts` — origin guard, tampered cookie rejection, rate-limit headers
  - `tests/e2e/session-persistence.spec.ts` — playwright: seals cookie in `beforeEach` via the same `lib/session-crypto`, asserts sameSite Strict, persists state across reload
  - `tests/responsive/responsive-audit.spec.ts` — 5-breakpoint visual audit (375 / 414 / 768 / 1024 / 1440)
  - `tests/walkthrough/walkthrough.spec.ts` — locked → verified → message → disconnect screenshot capture
- **Deps**: `@playwright/test ^1.59.1`, `vitest ^4.1.6`
- **New scripts**: `test` (vitest watch), `test:run` (vitest single-pass), `test:e2e` (playwright)

## Why prod build, not `next dev`
Tests against `next dev` catch fewer real bugs — Turbopack vs the production bundler emit different code, prod-only middleware/headers behave differently. Hitting the prod build matches what Vercel ships byte-for-byte.

## Why port 3010, not 3000
A developer typically has `pnpm dev` running on 3000 while pairing on features. Port 3010 lets the test runner start its own server without colliding. Same reason `.next-test/` is separate from `.next/`.

## Out of scope (intentional, deferred)
- **PR 12** — welcome-replay synchronous-latch fix
- **PR 13** — responsive polish + dead code cleanup
- **PR 14** — layered audio (orchestrator + Blob route + toggle)
- **PR 15** — README rewrite

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0 across full tree including tests/)
- [ ] `pnpm install` resolves cleanly with playwright + vitest
- [ ] Vercel preview turns green (`.next-test/` is gitignored from PR 3 so it doesn't pollute deploy artifacts)
- [ ] Locally: `pnpm test:run` — vitest specs pass
- [ ] Locally: `pnpm test:e2e` — playwright builds to `.next-test/`, starts on 3010, e2e specs pass
- [ ] Locally: `pnpm exec playwright test --config=walkthrough.config.ts` — captures the locked → verified → disconnect screenshot sequence