### PR TITLE
fix(frontend): welcome message replay — synchronous latch + hoisted message

### DIFF
--- a/frontend/lib/hooks/use-welcome-injection.ts
+++ b/frontend/lib/hooks/use-welcome-injection.ts
@@ -44,11 +44,27 @@ export function useWelcomeInjection({
     if (isRestoringChatState) return;
     if (hasInjectedRef.current) return;
 
+    // Critical: set the latch SYNCHRONOUSLY here, BEFORE setMessages.
+    // setMessages's updater is queued, not synchronous — if we set the
+    // ref inside the updater, React 18 StrictMode's second effect run
+    // still sees hasInjectedRef.current === false and queues a SECOND
+    // updater, double-injecting the welcome.
+    hasInjectedRef.current = true;
+
+    // Critical: construct the welcome message OUTSIDE the updater. Updaters
+    // must be pure — StrictMode invokes them twice for purity checks, and
+    // createAssistantMessage() generates a fresh UUID per call. Hoisting
+    // the construction guarantees the same object reference (same id)
+    // across both invocations, so the message list doesn't re-key and
+    // remount the typewriter.
+    const welcomeMessage = createAssistantMessage(WELCOME_MESSAGE, {
+      typingMs: WELCOME_TYPING_MS,
+    });
+
     setMessages((prev) => {
-      hasInjectedRef.current = true;
       const hasUserMessage = prev.some((message) => message.role === "user");
       if (hasUserMessage) return prev;
-      return [createAssistantMessage(WELCOME_MESSAGE, { typingMs: WELCOME_TYPING_MS })];
+      return [welcomeMessage];
     });
   }, [isApiKeyVerified, isRestoringChatState, setMessages]);
 }


### PR DESCRIPTION
## Summary
Two-part surgical fix to `use-welcome-injection`. User-visible symptom on `main` today: the welcome typewriter starts, stutters mid-phrase, and "restarts from the beginning" with the full message — only in dev (StrictMode), but the underlying double-injection is a real bug.

## The two coupled bugs

**Bug 1 — ref-latch set inside `setMessages` updater**
```ts
// before
setMessages((prev) => {
  hasInjectedRef.current = true;   // <-- queued, not synchronous
  return [createAssistantMessage(...)];
});
```
StrictMode dev double-invokes the effect. Between the two invocations, the queued updater has not yet applied, so `hasInjectedRef.current` is still `false` on the second pass — and a **second** updater gets queued.

**Bug 2 — `createAssistantMessage()` called inside the updater**
```ts
// before
setMessages((prev) => [createAssistantMessage(WELCOME_MESSAGE, ...)]);
```
React requires updaters to be **pure**. StrictMode invokes them twice for purity checks. `createAssistantMessage()` generates a fresh UUID each call — so the two invocations produce two **different** message objects, the list re-keys, `<TypewriterText>` remounts, animation restarts.

## The fix
```ts
// after
hasInjectedRef.current = true;  // synchronous — closes the StrictMode window

const welcomeMessage = createAssistantMessage(WELCOME_MESSAGE, {
  typingMs: WELCOME_TYPING_MS,
});                              // constructed once, stable id

setMessages((prev) => {
  const hasUserMessage = prev.some((m) => m.role === "user");
  return hasUserMessage ? prev : [welcomeMessage];
});                              // updater is now pure
```

`hasInjectedRef` still resets when `isApiKeyVerified` flips back to `false`, so re-verify after disconnect triggers a fresh welcome cleanly.

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0)
- [ ] Vercel preview turns green
- [ ] `pnpm dev` → verify a key → typewriter renders ONCE, smoothly, no restart
- [ ] Disconnect → verify again → welcome re-injects (latch reset works)
- [ ] DevTools console: zero "duplicate key" React warnings