### PR TITLE
fix(frontend): replace unsafe non-null assertion in /api/chat stream

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -207,9 +207,14 @@ export async function POST(request: Request): Promise<Response> {
   // Pipe OpenAI SSE → plain text content deltas. We strip the SSE
   // envelope on the server so the client (streamChatMessage) stays simple:
   // it just decodes UTF-8 chunks and appends them to the rendered message.
+  //
+  // Capture `upstream.body` in a local first — the !=null narrowing above
+  // doesn't survive the ReadableStream-constructor closure boundary, and a
+  // non-null assertion (upstream.body!) trips biome's noNonNullAssertion.
+  const upstreamBody = upstream.body;
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const reader = upstream.body!.getReader();
+      const reader = upstreamBody.getReader();
       const decoder = new TextDecoder();
       const encoder = new TextEncoder();
       let buffer = "";


### PR DESCRIPTION
## Summary
**Almost a no-op PR by design.** When I sat down to ship the PR 13 plan items, every one of them was already merged — the original PR 13 plan called for changes to `hero.tsx`, `connection-status-card.tsx`, `aurora-background.tsx`, `disclaimer-footer.tsx`, and `globals.css`, but those changes were already baked into the decomposed components the stash carried, and they shipped together in PR 5b.

| Original PR 13 plan item | Status on `main` |
|---|---|
| Hero h1 big-jump gated to `xl:` (1280+) | ✅ Already merged (PR 5b — `components/layout/hero.tsx:21`) |
| `ConnectionStatusCard` status text → `sr-only` at `max-[480px]` | ✅ Already merged (PR 5b — `components/chat/connection-status-card.tsx:53`) |
| Dead `BG_RIGHT_URL` + commented JSX removed | ✅ Already merged (PR 5b — `components/decoration/aurora-background.tsx`) |
| Footer image: explicit `width` / `height` / `loading` / `decoding` | ✅ Already merged (PR 5b — `components/layout/disclaimer-footer.tsx:17`) |
| Orphan CSS rules (`header__bg-2-img`, `footer__bg-img`, `rainbow-drift-b/c`) | ✅ Not present on `main` (verified via `grep`) |

So PR 13's actual content is the **one remaining biome lint warning** — a `noNonNullAssertion` in `app/api/chat/route.ts` where `upstream.body!.getReader()` was the path of least resistance after the `if (!upstream.body) return` guard. Replacing with a hoisted local capture keeps the narrowed type alive through the `ReadableStream` constructor closure, drops the unsafe `!`, and brings `pnpm lint` to **0 warnings** across 59 files.

## Diff
```diff
- const stream = new ReadableStream<Uint8Array>({
-   async start(controller) {
-     const reader = upstream.body!.getReader();
+ const upstreamBody = upstream.body;
+ const stream = new ReadableStream<Uint8Array>({
+   async start(controller) {
+     const reader = upstreamBody.getReader();
```

## Why this matters
The narrowing-via-`!` works *today* but is brittle: a future refactor that moves the `if (!upstream.body)` guard somewhere else (e.g., inside a try-catch) wouldn't break TypeScript — the `!` would silently lie about a now-nullable value, and we'd get a runtime `Cannot read property 'getReader' of undefined`. The hoisted local capture closes that footgun.

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified locally: `tsc --noEmit` exit 0)
- [ ] `pnpm lint` — 0 warnings (verified locally: biome `Checked 59 files. No fixes applied.`)
- [ ] Vercel preview turns green
- [ ] Manual: `/api/chat` still streams correctly after the change (functional behavior unchanged)