### PR TITLE
fix(frontend): stabilize TypewriterText animation against parent re-renders

### DIFF
--- a/frontend/components/chat/typewriter-text.tsx
+++ b/frontend/components/chat/typewriter-text.tsx
@@ -34,6 +34,17 @@ export function TypewriterText({
   const [visibleText, setVisibleText] = useState(shouldAnimate ? "" : text);
   const doneRef = useRef(false);
 
+  // Stable handle for the animation-complete callback. The parent passes
+  // an inline arrow each render (e.g. `() => onAnimationDone(message.id)`
+  // in MessageList) — depending on its identity in the animation effect
+  // would restart the typewriter on every unrelated parent re-render
+  // (sound fade ticks, persist effects, scroll updates). The ref keeps
+  // the effect deps stable.
+  const onAnimationDoneRef = useRef(onAnimationDone);
+  useEffect(() => {
+    onAnimationDoneRef.current = onAnimationDone;
+  }, [onAnimationDone]);
+
   const frames = useMemo(() => {
     if (!shouldAnimate) {
       return [text];
@@ -58,7 +69,7 @@ export function TypewriterText({
       setVisibleText(text);
       if (!doneRef.current) {
         doneRef.current = true;
-        onAnimationDone?.();
+        onAnimationDoneRef.current?.();
       }
       return;
     }
@@ -76,7 +87,7 @@ export function TypewriterText({
         window.clearInterval(timer);
         if (!doneRef.current) {
           doneRef.current = true;
-          onAnimationDone?.();
+          onAnimationDoneRef.current?.();
         }
       }
     }, stepMs);
@@ -84,7 +95,9 @@ export function TypewriterText({
     return () => {
       window.clearInterval(timer);
     };
-  }, [durationMs, frames, onAnimationDone, shouldAnimate, text]);
+    // onAnimationDone intentionally NOT in deps — read via ref above.
+    // Including it would restart the typewriter on every parent re-render.
+  }, [durationMs, frames, shouldAnimate, text]);
 
   return <>{visibleText}</>;
 }


### PR DESCRIPTION
## Summary
Real root cause of the welcome-message-restart bug — separate from PR 12's StrictMode fix, fires in production.

## The bug
`TypewriterText` had `onAnimationDone` in its animation effect's dependency array. `MessageList` passes it as an inline arrow:

```tsx
onAnimationDone={() => onAnimationDone(message.id)}
```

That arrow has a **fresh identity on every parent render**. Sound fade ticks, persist effects, scroll updates — anything that re-renders the chat shell — bubbles down to MessageList, recreates the arrow, TypewriterText sees a "new" prop, the effect re-runs, and the first thing it does is `setVisibleText("")` → typewriter restarts from frame zero.

Visible symptom: welcome starts typing, gets a few words in, suddenly clears, types again from the beginning.

## The fix
Standard React pattern for "fire this callback when the effect's work completes, but don't tie the effect to caller render cycle":

```tsx
const onAnimationDoneRef = useRef(onAnimationDone);
useEffect(() => {
  onAnimationDoneRef.current = onAnimationDone;
}, [onAnimationDone]);

// ... animation effect now reads via ref, no onAnimationDone in deps
}, [durationMs, frames, shouldAnimate, text]);
```

- Animation effect now only re-runs when `text` / `durationMs` / `shouldAnimate` / `frames` actually change
- Parent re-renders are invisible to it
- `onAnimationDone` still fires exactly once when the animation completes — semantics unchanged

## Why PR 12 didn't catch this
PR 12 targeted React 18 StrictMode's dev double-invoke (which caused two welcomes to be injected, two different message IDs, list re-key, TypewriterText remount). That was a real bug; the fix was correct for *that* scenario. But it was solving a different problem than this one — PR 12 prevented a SECOND injection; this PR prevents the first injection's typewriter from being interrupted by parent re-renders.

## Test plan
- [ ] `pnpm typecheck` — 0 errors (verified: exit 0)
- [ ] `pnpm lint` — 0 warnings (verified: 64 files, no issues)
- [ ] Vercel preview turns green
- [ ] Live: paste a key → click Verify → welcome typewriter runs **once, smoothly, no restart**, even while crowd ambience is fading in