### PR TITLE
revert: undo PR #22 — unblock polish branch cherry-picks

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,12 +3,10 @@
 
 /* ─────────────────────────────────────────────────────────────────────────
    Design tokens — Tailwind v4 @theme directive.
-   Every `--color-*` token is auto-exposed as a Tailwind utility:
+   Every `--color-*` token below is auto-exposed as a Tailwind utility:
      bg-bg-warm, text-aurora-cyan, border-glass-border, fill-signal-success, …
-   Every `--animate-*` token registers an animation and emits an
-   `animate-{name}` utility class (tree-shaken when unused).
-   @keyframes definitions live inside @theme alongside the tokens that
-   reference them so the animation surface is colocated.
+   The token names follow the Tailwind v4 convention so they integrate with
+   the rest of the framework (variants, modifiers, color-mix, etc.).
    ───────────────────────────────────────────────────────────────────────── */
 @theme {
   /* Cinematic vignette — daylight center, indigo deepening at edges. */
@@ -38,331 +36,106 @@
   --color-signal-success: #34d399;
   --color-signal-error: #fb7185;
   --color-signal-warn: #fbbf24;
+}
 
-  /* Animation tokens — each emits an `animate-{name}` utility. */
-  --animate-rainbow-drift-a: rainbow-drift-a 12s ease-in-out infinite alternate;
-  --animate-rainbow-drift-d: rainbow-drift-d 15s ease-in-out infinite alternate;
-  --animate-aurora-particles-drift: aurora-particles-drift 60s linear infinite alternate;
-  --animate-aurora-pill-breathe: aurora-pill-breathe 4.5s ease-in-out infinite;
-  --animate-aurora-pill-sweep: aurora-pill-sweep 9s ease-in-out infinite;
-  --animate-status-dot-pulse: status-dot-pulse 2s ease-in-out infinite;
-  --animate-prism-sweep: prism-sweep 8s ease-in-out infinite;
-  --animate-panel-in: panel-in 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
-  --animate-panel-out: panel-out 180ms cubic-bezier(0.4, 0, 1, 1) both;
-  --animate-shell-burst-glow: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
-  --animate-locked-verify-breathe: locked-verify-breathe 4s ease-in-out infinite;
-  --animate-shell-aurora-drift: shell-aurora-drift 16s ease-in-out infinite alternate;
-  --animate-avatar-aurora-spin: avatar-aurora-spin 7s linear infinite;
-  --animate-avatar-aurora-breathe: avatar-aurora-breathe 3.4s ease-in-out infinite;
-  --animate-dot-pulse: dot-pulse 1s ease-in-out infinite;
+:root {
+  color-scheme: dark;
 
-  /* Keyframes — paired with their --animate-* token above. */
-  @keyframes rainbow-drift-a {
-    from {
-      transform: translate3d(-3%, -1.5%, 0) scale(1.01);
-    }
-    to {
-      transform: translate3d(6%, 4.5%, 0) scale(1.05);
-    }
-  }
+  /* Chat shell heights — drive the locked → unlocked expansion animation.
+     Kept in `:root` (not `@theme`) because Tailwind v4 doesn't have a height
+     namespace; consumed via `var(...)` in the `.chat-shell-frame` rule. */
+  --shell-h-locked: clamp(320px, 44svh, 380px);
+  --shell-h-unlocked: 72svh;
+  --shell-max-h-unlocked: 820px;
+}
 
-  @keyframes rainbow-drift-d {
-    from {
-      transform: translate3d(2%, 2%, 0) scale(1.01);
-    }
-    to {
-      transform: translate3d(-6.5%, -5.5%, 0) scale(1.06);
-    }
-  }
-
-  @keyframes aurora-particles-drift {
-    from {
-      transform: translate3d(0, 0, 0);
-    }
-    to {
-      transform: translate3d(2.4%, -1.4%, 0);
-    }
-  }
-
-  @keyframes aurora-pill-breathe {
-    0%,
-    100% {
-      box-shadow:
-        0 0 12px rgba(167, 139, 250, 0.28),
-        0 0 24px rgba(125, 249, 255, 0.14);
-    }
-    50% {
-      box-shadow:
-        0 0 18px rgba(167, 139, 250, 0.48),
-        0 0 38px rgba(125, 249, 255, 0.24);
-    }
-  }
-
-  @keyframes aurora-pill-sweep {
-    0%,
-    100% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-  }
-
-  @keyframes status-dot-pulse {
-    0%,
-    100% {
-      box-shadow:
-        0 0 6px rgba(110, 231, 183, 0.7),
-        0 0 0 0 rgba(110, 231, 183, 0);
-      transform: scale(1);
-    }
-    50% {
-      box-shadow:
-        0 0 14px rgba(110, 231, 183, 1),
-        0 0 22px rgba(110, 231, 183, 0.55);
-      transform: scale(1.14);
-    }
-  }
-
-  @keyframes prism-sweep {
-    0%,
-    100% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-  }
-
-  @keyframes panel-in {
-    from {
-      opacity: 0;
-      transform: translateY(8px) scale(0.99);
-      filter: blur(3px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-      filter: blur(0);
-    }
-  }
-
-  @keyframes panel-out {
-    from {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-      filter: blur(0);
-    }
-    to {
-      opacity: 0;
-      transform: translateY(-6px) scale(0.995);
-      filter: blur(2px);
-    }
-  }
-
-  @keyframes shell-burst-glow {
-    0% {
-      box-shadow:
-        0 22px 56px rgba(2, 8, 28, 0.42),
-        0 6px 18px rgba(2, 8, 28, 0.24),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18);
-    }
-    35% {
-      box-shadow:
-        0 22px 56px rgba(2, 8, 28, 0.42),
-        0 6px 18px rgba(2, 8, 28, 0.24),
-        0 0 60px rgba(125, 249, 255, 0.55),
-        0 0 110px rgba(167, 139, 250, 0.4),
-        0 0 180px rgba(244, 114, 182, 0.2),
-        inset 0 1px 0 rgba(255, 255, 255, 0.36);
-    }
-    100% {
-      box-shadow:
-        0 22px 56px rgba(2, 8, 28, 0.42),
-        0 6px 18px rgba(2, 8, 28, 0.24),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18);
-    }
-  }
-
-  @keyframes locked-verify-breathe {
-    0%,
-    100% {
-      box-shadow:
-        0 14px 32px rgba(8, 47, 73, 0.22),
-        0 0 18px rgba(125, 249, 255, 0.28),
-        inset 0 1px 0 rgba(255, 255, 255, 0.86);
-    }
-    50% {
-      box-shadow:
-        0 14px 32px rgba(8, 47, 73, 0.22),
-        0 0 28px rgba(125, 249, 255, 0.55),
-        0 0 48px rgba(167, 139, 250, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.86);
-    }
-  }
-
-  @keyframes shell-aurora-drift {
-    0% {
-      transform: translate3d(0, 0, 0) scale(1);
-      opacity: 0.78;
-    }
-    50% {
-      transform: translate3d(3.4%, -2.6%, 0) scale(1.08);
-      opacity: 1;
-    }
-    100% {
-      transform: translate3d(-3%, 3.2%, 0) scale(1.04);
-      opacity: 0.86;
-    }
-  }
-
-  @keyframes avatar-aurora-spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  @keyframes avatar-aurora-breathe {
-    0%,
-    100% {
-      opacity: 0.55;
-      filter: blur(6px);
-    }
-    50% {
-      opacity: 1;
-      filter: blur(10px);
-    }
-  }
-
-  @keyframes dot-pulse {
-    0%,
-    80%,
-    100% {
-      transform: scale(0.7);
-      opacity: 0.45;
-    }
-    40% {
-      transform: scale(1);
-      opacity: 1;
-    }
+@media (min-width: 640px) {
+  :root {
+    --shell-h-locked: clamp(340px, 42svh, 400px);
+    --shell-h-unlocked: 74svh;
   }
 }
 
-@layer base {
+@media (min-width: 1024px) {
   :root {
-    color-scheme: dark;
-
-    /* Chat shell heights — drive the locked → unlocked expansion animation.
-       Kept in `:root` (not `@theme`) because Tailwind v4 has no `height`
-       namespace; consumed via `var(...)` in the .chat-shell-frame @utility. */
-    --shell-h-locked: clamp(320px, 44svh, 380px);
-    --shell-h-unlocked: 72svh;
-    --shell-max-h-unlocked: 820px;
+    --shell-h-locked: clamp(360px, 40svh, 440px);
+    --shell-h-unlocked: 66svh;
+    --shell-max-h-unlocked: 720px;
   }
+}
 
-  @media (min-width: 640px) {
-    :root {
-      --shell-h-locked: clamp(340px, 42svh, 400px);
-      --shell-h-unlocked: 74svh;
-    }
+@media (min-width: 1280px) {
+  :root {
+    --shell-h-locked: clamp(380px, 42svh, 460px);
+    --shell-h-unlocked: 68svh;
+    --shell-max-h-unlocked: 760px;
   }
+}
 
-  @media (min-width: 1024px) {
-    :root {
-      --shell-h-locked: clamp(360px, 40svh, 440px);
-      --shell-h-unlocked: 66svh;
-      --shell-max-h-unlocked: 720px;
-    }
+@media (min-width: 1536px) {
+  :root {
+    --shell-h-locked: clamp(400px, 44svh, 480px);
+    --shell-max-h-unlocked: 800px;
   }
+}
 
-  @media (min-width: 1280px) {
-    :root {
-      --shell-h-locked: clamp(380px, 42svh, 460px);
-      --shell-h-unlocked: 68svh;
-      --shell-max-h-unlocked: 760px;
-    }
-  }
+* {
+  box-sizing: border-box;
+}
 
-  @media (min-width: 1536px) {
-    :root {
-      --shell-h-locked: clamp(400px, 44svh, 480px);
-      --shell-max-h-unlocked: 800px;
-    }
-  }
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--color-text-primary);
+  /* Cinematic vignette: daylight center where the hero + chat live, indigo
+     deepening toward the edges. The vignette funnels the eye inward without
+     darkening the reading zone. Aurora blobs add diffuse rainbow glow that
+     compounds with the rainbow SVG layers above. */
+  background:
+    radial-gradient(circle at 18% 18%, var(--color-aurora-cyan), transparent 34%),
+    radial-gradient(circle at 86% 15%, var(--color-aurora-magenta), transparent 36%),
+    radial-gradient(circle at 48% 88%, var(--color-aurora-amber), transparent 38%),
+    radial-gradient(
+      ellipse 95% 75% at 50% 38%,
+      var(--color-bg-warm) 0%,
+      var(--color-bg-mid) 38%,
+      var(--color-bg-deep) 68%,
+      var(--color-bg-edge-indigo) 88%,
+      var(--color-bg-edge-deep) 100%
+    );
+  background-attachment: fixed;
+  cursor:
+    url("https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766") 16 16,
+    auto;
+}
 
-  * {
-    box-sizing: border-box;
-  }
+/* Clickable surfaces show the standard OS pointer, not the heart, so the
+   user can tell at a glance what is interactive vs. decorative. */
+a,
+button,
+[role="button"],
+[type="submit"],
+[type="button"],
+label[for] {
+  cursor: pointer;
+}
 
-  html,
-  body {
-    margin: 0;
-    padding: 0;
-    min-height: 100%;
-    font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    color: var(--color-text-primary);
-    /* Cinematic vignette: daylight center where the hero + chat live, indigo
-       deepening toward the edges. The vignette funnels the eye inward without
-       darkening the reading zone. Aurora blobs add diffuse rainbow glow that
-       compounds with the rainbow SVG layers above. */
-    background:
-      radial-gradient(circle at 18% 18%, var(--color-aurora-cyan), transparent 34%),
-      radial-gradient(circle at 86% 15%, var(--color-aurora-magenta), transparent 36%),
-      radial-gradient(circle at 48% 88%, var(--color-aurora-amber), transparent 38%),
-      radial-gradient(
-        ellipse 95% 75% at 50% 38%,
-        var(--color-bg-warm) 0%,
-        var(--color-bg-mid) 38%,
-        var(--color-bg-deep) 68%,
-        var(--color-bg-edge-indigo) 88%,
-        var(--color-bg-edge-deep) 100%
-      );
-    background-attachment: fixed;
-    cursor:
-      url("https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766") 16 16,
-      auto;
-  }
+button:disabled,
+[role="button"][aria-disabled="true"],
+button[aria-disabled="true"] {
+  cursor: not-allowed;
+}
 
-  /* Clickable surfaces show the standard OS pointer, not the heart, so the
-     user can tell at a glance what is interactive vs. decorative. */
-  a,
-  button,
-  [role="button"],
-  [type="submit"],
-  [type="button"],
-  label[for] {
-    cursor: pointer;
-  }
-
-  button:disabled,
-  [role="button"][aria-disabled="true"],
-  button[aria-disabled="true"] {
-    cursor: not-allowed;
-  }
-
-  input,
-  textarea {
-    cursor: text;
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
+input,
+textarea {
+  cursor: text;
 }
 
 /* Coldplay Moon Music style background graphics, layered like the official site. */
-@utility global-graphics {
+.global-graphics {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -370,71 +143,67 @@
   overflow: hidden;
   z-index: -1;
   pointer-events: none;
-
-  &::before,
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-  }
-
-  /* Ambient particle dust — tiny light points drifting slowly across the canvas.
-     Pure CSS (no JS), respects prefers-reduced-motion via the global override
-     below. Adds subliminal "alive" depth without competing with the aurora. */
-  &::before {
-    background:
-      radial-gradient(1.2px 1.2px at 12% 22%, rgba(255, 255, 255, 0.55), transparent 60%),
-      radial-gradient(1.4px 1.4px at 28% 78%, rgba(255, 255, 255, 0.45), transparent 60%),
-      radial-gradient(1px 1px at 48% 14%, rgba(196, 228, 255, 0.5), transparent 60%),
-      radial-gradient(1.6px 1.6px at 64% 64%, rgba(255, 255, 255, 0.45), transparent 60%),
-      radial-gradient(1.2px 1.2px at 82% 32%, rgba(220, 232, 255, 0.55), transparent 60%),
-      radial-gradient(1.4px 1.4px at 92% 86%, rgba(255, 255, 255, 0.4), transparent 60%),
-      radial-gradient(1px 1px at 38% 46%, rgba(255, 255, 255, 0.42), transparent 60%),
-      radial-gradient(1.2px 1.2px at 72% 12%, rgba(220, 240, 255, 0.5), transparent 60%);
-    opacity: 0.7;
-    animation: aurora-particles-drift 60s linear infinite alternate;
-  }
-
-  &::after {
-    background: none;
-    animation: none;
-  }
 }
 
-@utility header__bg-img {
+.global-graphics::before,
+.global-graphics::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Ambient particle dust — tiny light points drifting slowly across the canvas.
+   Pure CSS (no JS), respects prefers-reduced-motion via the global override
+   below. Adds subliminal "alive" depth without competing with the aurora. */
+.global-graphics::before {
+  background:
+    radial-gradient(1.2px 1.2px at 12% 22%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(1.4px 1.4px at 28% 78%, rgba(255, 255, 255, 0.45), transparent 60%),
+    radial-gradient(1px 1px at 48% 14%, rgba(196, 228, 255, 0.5), transparent 60%),
+    radial-gradient(1.6px 1.6px at 64% 64%, rgba(255, 255, 255, 0.45), transparent 60%),
+    radial-gradient(1.2px 1.2px at 82% 32%, rgba(220, 232, 255, 0.55), transparent 60%),
+    radial-gradient(1.4px 1.4px at 92% 86%, rgba(255, 255, 255, 0.4), transparent 60%),
+    radial-gradient(1px 1px at 38% 46%, rgba(255, 255, 255, 0.42), transparent 60%),
+    radial-gradient(1.2px 1.2px at 72% 12%, rgba(220, 240, 255, 0.5), transparent 60%);
+  opacity: 0.7;
+  animation: aurora-particles-drift 60s linear infinite alternate;
+}
+
+.global-graphics::after {
+  background: none;
+  animation: none;
+}
+
+.header__bg-img,
+.footer__bg-2-img {
   position: absolute;
   display: block;
   width: clamp(420px, 78vw, 1640px);
   line-height: 0;
+}
+
+@media (max-width: 640px) {
+  .header__bg-img,
+  .footer__bg-2-img {
+    width: clamp(280px, 90vw, 520px);
+  }
+}
+
+.header__bg-img {
   top: -16%;
   left: -6%;
   animation: rainbow-drift-a 12s ease-in-out infinite alternate;
-
-  @media (max-width: 640px) {
-    width: clamp(280px, 90vw, 520px);
-  }
 }
 
-@utility footer__bg-2-img {
-  position: absolute;
-  display: block;
-  width: clamp(420px, 78vw, 1640px);
-  line-height: 0;
+.footer__bg-2-img {
   bottom: -8%;
   right: -6%;
   animation: rainbow-drift-d 15s ease-in-out infinite alternate;
-
-  @media (max-width: 640px) {
-    width: clamp(280px, 90vw, 520px);
-  }
-
-  & .footer__bg {
-    transform: scaleX(-1);
-  }
 }
 
-@utility header__bg {
+.header__bg,
+.footer__bg {
   display: block;
   width: 100%;
   height: auto;
@@ -445,19 +214,53 @@
   filter: saturate(1.55) contrast(1.08) brightness(1.04);
 }
 
-@utility footer__bg {
-  display: block;
-  width: 100%;
-  height: auto;
-  opacity: 1;
-  mix-blend-mode: screen;
-  filter: saturate(1.55) contrast(1.08) brightness(1.04);
+.footer__bg-2-img .footer__bg {
+  transform: scaleX(-1);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes rainbow-drift-a {
+  from {
+    transform: translate3d(-3%, -1.5%, 0) scale(1.01);
+  }
+  to {
+    transform: translate3d(6%, 4.5%, 0) scale(1.05);
+  }
+}
+
+@keyframes rainbow-drift-d {
+  from {
+    transform: translate3d(2%, 2%, 0) scale(1.01);
+  }
+  to {
+    transform: translate3d(-6.5%, -5.5%, 0) scale(1.06);
+  }
+}
+
+@keyframes aurora-particles-drift {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(2.4%, -1.4%, 0);
+  }
 }
 
 /* Aurora pill — gradient-bordered label with a soft breathing outer glow.
    Connects every "chrome label" (hero pill, status pill) to the prism
    palette without stealing focus from the chat content. */
-@utility aurora-pill {
+.aurora-pill {
   position: relative;
   isolation: isolate;
   background: rgba(255, 255, 255, 0.08);
@@ -465,44 +268,94 @@
     0 0 12px rgba(167, 139, 250, 0.28),
     0 0 24px rgba(125, 249, 255, 0.14);
   animation: aurora-pill-breathe 4.5s ease-in-out infinite;
+}
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    padding: 1px;
-    background: linear-gradient(
-      120deg,
-      rgba(125, 249, 255, 0.85),
-      rgba(167, 139, 250, 0.85) 38%,
-      rgba(244, 113, 181, 0.85) 68%,
-      rgba(253, 224, 71, 0.7)
-    );
-    background-size: 220% 100%;
-    -webkit-mask:
-      linear-gradient(#fff 0 0) content-box,
-      linear-gradient(#fff 0 0);
-    mask:
-      linear-gradient(#fff 0 0) content-box,
-      linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
-    animation: aurora-pill-sweep 9s ease-in-out infinite;
+.aurora-pill::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    120deg,
+    rgba(125, 249, 255, 0.85),
+    rgba(167, 139, 250, 0.85) 38%,
+    rgba(244, 113, 181, 0.85) 68%,
+    rgba(253, 224, 71, 0.7)
+  );
+  background-size: 220% 100%;
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  animation: aurora-pill-sweep 9s ease-in-out infinite;
+}
+
+@keyframes aurora-pill-breathe {
+  0%,
+  100% {
+    box-shadow:
+      0 0 12px rgba(167, 139, 250, 0.28),
+      0 0 24px rgba(125, 249, 255, 0.14);
+  }
+  50% {
+    box-shadow:
+      0 0 18px rgba(167, 139, 250, 0.48),
+      0 0 38px rgba(125, 249, 255, 0.24);
+  }
+}
+
+@keyframes aurora-pill-sweep {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
   }
 }
 
 /* Live connection status dot — soft breathing pulse signals "the AI is
    reachable right now." 2s cycle stays calm; double-shadow gives a halo. */
-@utility status-dot-live {
+.status-dot-live {
   animation: status-dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes status-dot-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 6px rgba(110, 231, 183, 0.7),
+      0 0 0 0 rgba(110, 231, 183, 0);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow:
+      0 0 14px rgba(110, 231, 183, 1),
+      0 0 22px rgba(110, 231, 183, 0.55);
+    transform: scale(1.14);
+  }
 }
 
 /* Prism line — the app's signature element. A thin gradient bar under the
    hero H1 with a slow sweeping animation. Echoes Coldplay's prism motif
    without copying any specific brand mark. Becomes the visual fingerprint. */
-@utility prism-line {
+@keyframes prism-sweep {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+.prism-line {
   display: block;
   height: 1.5px;
   width: clamp(220px, 28vw, 360px);
@@ -526,7 +379,7 @@
 }
 
 /* Reusable gradient hairline — used for chat-header divider and page-bottom divider. */
-@utility gradient-hairline {
+.gradient-hairline {
   height: 1.5px;
   background: linear-gradient(
     90deg,
@@ -541,11 +394,90 @@
     0 0 16px rgba(125, 249, 255, 0.18);
 }
 
-@utility panel-enter {
+@keyframes global-canvas-drift {
+  from {
+    transform: translate3d(-1.2%, 0.8%, 0) scale(1.01);
+    filter: saturate(1.02);
+  }
+  to {
+    transform: translate3d(1.4%, -1.1%, 0) scale(1.04);
+    filter: saturate(1.12);
+  }
+}
+
+@keyframes page-aurora-flow {
+  from {
+    background-position:
+      0% 0%,
+      100% 0%,
+      50% 100%,
+      0% 0%;
+    filter: saturate(1);
+  }
+  to {
+    background-position:
+      24% -16%,
+      72% 18%,
+      34% 86%,
+      0% 0%;
+    filter: saturate(1.12);
+  }
+}
+
+@keyframes ambient-glow-drift {
+  from {
+    transform: translate3d(-1.2%, 0.5%, 0) scale(1);
+    opacity: 0.92;
+  }
+  to {
+    transform: translate3d(1.4%, -0.8%, 0) scale(1.03);
+    opacity: 1;
+  }
+}
+
+@keyframes ambient-vignette-pulse {
+  0%,
+  100% {
+    opacity: 0.9;
+    filter: saturate(1);
+  }
+  50% {
+    opacity: 1;
+    filter: saturate(1.08);
+  }
+}
+
+@keyframes panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+    filter: blur(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes panel-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.995);
+    filter: blur(2px);
+  }
+}
+
+.panel-enter {
   animation: panel-in 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
-@utility panel-exit {
+.panel-exit {
   animation: panel-out 180ms cubic-bezier(0.4, 0, 1, 1) both;
 }
 
@@ -553,7 +485,7 @@
    heights using a soft spring curve. The parent flex column is justify-center,
    so as height changes the shell visually expands/contracts from its vertical
    center (both up and down simultaneously). */
-@utility chat-shell-frame {
+.chat-shell-frame {
   display: flex;
   align-items: stretch;
   height: var(--shell-h-unlocked);
@@ -561,35 +493,59 @@
   transition:
     height 720ms cubic-bezier(0.34, 1.42, 0.55, 1),
     max-height 720ms cubic-bezier(0.34, 1.42, 0.55, 1);
+}
 
-  &[data-state="locked"] {
-    height: var(--shell-h-locked);
-    max-height: var(--shell-h-locked);
-  }
+.chat-shell-frame[data-state="locked"] {
+  height: var(--shell-h-locked);
+  max-height: var(--shell-h-locked);
+}
 
-  /* One-shot glow burst — fires whenever the shell flips locked↔unlocked.
-     The 900ms cyan/violet halo flash makes the height transition feel
-     *magical* rather than mechanical; users see and feel the moment. */
-  &.shell-burst .chat-shell-glass {
-    animation: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
-  }
+/* One-shot glow burst — fires whenever the shell flips locked↔unlocked.
+   The 900ms cyan/violet halo flash makes the height transition feel
+   *magical* rather than mechanical; users see and feel the moment. */
+.chat-shell-frame.shell-burst .chat-shell-glass {
+  animation: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
+}
 
-  /* Locked-state aurora bump — when the shell is in locked mode, the inner
-     aurora glow runs warmer + faster to make the compact card feel focused
-     and lit. Reverts to baseline on unlock. */
-  &[data-state="locked"] .chat-shell-glass::after {
-    background:
-      radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.4), transparent 62%),
-      radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.36), transparent 62%),
-      radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.32), transparent 62%);
-    animation-duration: 12s;
+@keyframes shell-burst-glow {
+  0% {
+    box-shadow:
+      0 22px 56px rgba(2, 8, 28, 0.42),
+      0 6px 18px rgba(2, 8, 28, 0.24),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
   }
+  35% {
+    box-shadow:
+      0 22px 56px rgba(2, 8, 28, 0.42),
+      0 6px 18px rgba(2, 8, 28, 0.24),
+      0 0 60px rgba(125, 249, 255, 0.55),
+      0 0 110px rgba(167, 139, 250, 0.4),
+      0 0 180px rgba(244, 114, 182, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.36);
+  }
+  100% {
+    box-shadow:
+      0 22px 56px rgba(2, 8, 28, 0.42),
+      0 6px 18px rgba(2, 8, 28, 0.24),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  }
+}
+
+/* Locked-state aurora bump — when the shell is in locked mode, the inner
+   aurora glow runs warmer + faster to make the compact card feel focused
+   and lit. Reverts to baseline on unlock. */
+.chat-shell-frame[data-state="locked"] .chat-shell-glass::after {
+  background:
+    radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.4), transparent 62%),
+    radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.36), transparent 62%),
+    radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.32), transparent 62%);
+  animation-duration: 12s;
 }
 
 /* Animated gradient ring around the locked-state input. Uses the prism
    palette — cohesive with the prism line, hero "Coldplay" gradient, and
    the lit eyebrow. Cyan → violet → fuchsia → amber → cyan sweep. */
-@utility locked-input-ring {
+.locked-input-ring {
   position: relative;
   isolation: isolate;
   border-radius: 0.5rem;
@@ -607,17 +563,34 @@
   box-shadow:
     0 0 14px rgba(167, 139, 250, 0.4),
     0 0 28px rgba(125, 249, 255, 0.22);
+}
 
-  & > * {
-    border-radius: calc(0.5rem - 1px);
-  }
+.locked-input-ring > * {
+  border-radius: calc(0.5rem - 1px);
 }
 
 /* Verify-button breathing glow for the locked-state CTA. Uses the existing
    aurora-pill-breathe keyframe so the visual language stays in family. */
-@utility locked-verify-btn {
+.locked-verify-btn {
   position: relative;
   animation: locked-verify-breathe 4s ease-in-out infinite;
+}
+
+@keyframes locked-verify-breathe {
+  0%,
+  100% {
+    box-shadow:
+      0 14px 32px rgba(8, 47, 73, 0.22),
+      0 0 18px rgba(125, 249, 255, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.86);
+  }
+  50% {
+    box-shadow:
+      0 14px 32px rgba(8, 47, 73, 0.22),
+      0 0 28px rgba(125, 249, 255, 0.55),
+      0 0 48px rgba(167, 139, 250, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.86);
+  }
 }
 
 /* Outer chat shell: DARK glass — the content well. Light hero + bright aurora
@@ -625,7 +598,7 @@
    This is the FAANG/modern-AI-chat pattern: ChatGPT, Claude.ai, Gemini all
    put the conversation in the darkest zone on the page so the bright
    surrounding palette becomes the frame and text contrast is maximal. */
-@utility chat-shell-glass {
+.chat-shell-glass {
   border-radius: 1.5rem;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(9, 20, 50, 0.72);
@@ -637,105 +610,157 @@
     0 22px 56px rgba(2, 8, 28, 0.42),
     0 6px 18px rgba(2, 8, 28, 0.24),
     inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
 
-  /* Subtle top-down sheen, gives the glass its "lit edge" highlight. */
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    background: radial-gradient(
-      ellipse at 50% 0%,
-      rgba(255, 255, 255, 0.14) 0%,
-      rgba(255, 255, 255, 0.05) 35%,
-      rgba(255, 255, 255, 0) 72%
-    );
+/* Subtle top-down sheen, gives the glass its "lit edge" highlight. */
+.chat-shell-glass::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse at 50% 0%,
+    rgba(255, 255, 255, 0.14) 0%,
+    rgba(255, 255, 255, 0.05) 35%,
+    rgba(255, 255, 255, 0) 72%
+  );
+}
+
+/* Inner ambient aurora — cyan/magenta/violet blobs that visibly drift inside
+   the chat shell so the conversation zone feels alive. Higher alpha now
+   (mix-blend-mode was washing the colors out against the white glass) and
+   a faster cycle so the motion actually registers. */
+.chat-shell-glass::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.34), transparent 62%),
+    radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.3), transparent 62%),
+    radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.26), transparent 62%);
+  animation: shell-aurora-drift 16s ease-in-out infinite alternate;
+}
+
+.chat-shell-glass > * {
+  position: relative;
+  z-index: 1;
+}
+
+@keyframes shell-aurora-drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.78;
   }
-
-  /* Inner ambient aurora — cyan/magenta/violet blobs that visibly drift inside
-     the chat shell so the conversation zone feels alive. Higher alpha now
-     (mix-blend-mode was washing the colors out against the white glass) and
-     a faster cycle so the motion actually registers. */
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.34), transparent 62%),
-      radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.3), transparent 62%),
-      radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.26), transparent 62%);
-    animation: shell-aurora-drift 16s ease-in-out infinite alternate;
+  50% {
+    transform: translate3d(3.4%, -2.6%, 0) scale(1.08);
+    opacity: 1;
   }
-
-  & > * {
-    position: relative;
-    z-index: 1;
+  100% {
+    transform: translate3d(-3%, 3.2%, 0) scale(1.04);
+    opacity: 0.86;
   }
 }
 
 /* AI avatar focal pulse — a soft aurora ring that breathes around the
    Sparkles avatar. Signals "the AI is alive" with a single focal point of
    motion that the eye naturally tracks during conversation. */
-@utility ai-avatar-aurora {
+.ai-avatar-aurora {
   position: relative;
+}
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: -4px;
-    border-radius: 9999px;
-    background: conic-gradient(
-      from 0deg,
-      rgba(125, 249, 255, 0.55),
-      rgba(167, 139, 250, 0.55),
-      rgba(244, 114, 182, 0.55),
-      rgba(253, 224, 71, 0.55),
-      rgba(125, 249, 255, 0.55)
-    );
-    filter: blur(7px);
-    z-index: -1;
-    opacity: 0.85;
-    animation:
-      avatar-aurora-spin 7s linear infinite,
-      avatar-aurora-breathe 3.4s ease-in-out infinite;
+.ai-avatar-aurora::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 9999px;
+  background: conic-gradient(
+    from 0deg,
+    rgba(125, 249, 255, 0.55),
+    rgba(167, 139, 250, 0.55),
+    rgba(244, 114, 182, 0.55),
+    rgba(253, 224, 71, 0.55),
+    rgba(125, 249, 255, 0.55)
+  );
+  filter: blur(7px);
+  z-index: -1;
+  opacity: 0.85;
+  animation:
+    avatar-aurora-spin 7s linear infinite,
+    avatar-aurora-breathe 3.4s ease-in-out infinite;
+}
+
+@keyframes avatar-aurora-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }
 
+@keyframes avatar-aurora-breathe {
+  0%,
+  100% {
+    opacity: 0.55;
+    filter: blur(6px);
+  }
+  50% {
+    opacity: 1;
+    filter: blur(10px);
+  }
+}
+
+/* Inner controls: quiet, transparent — never compete with the outer glass.
+   A barely-there stroke gives shape; no second backdrop-filter (one blur layer
+   wins on GPU and visually). */
+.aurora-control {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
 /* Conversation area: fully transparent. The outer glass shell IS the surface. */
-@utility conversation-surface {
+.conversation-surface {
   border: none;
   background: transparent;
   box-shadow: none;
 }
 
-/* Landing hero: keeps the copy readable against the animated background while
-   still feeling airy and outside the chat shell. */
-@utility hero-copy {
-  position: relative;
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: -12% 12% auto;
-    height: clamp(160px, 24vw, 280px);
-    border-radius: 9999px;
-    background: radial-gradient(
-      ellipse at center,
-      rgba(255, 255, 255, 0.18) 0%,
-      rgba(164, 244, 255, 0.1) 36%,
-      rgba(255, 255, 255, 0) 72%
-    );
-    filter: blur(16px);
-    pointer-events: none;
-    z-index: -1;
-  }
+/* Locked-state callout: subtle quiet panel (no heavy shadow / no second blur). */
+.spotlight-card {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
 }
 
-@utility aurora-button {
+/* Landing hero: keeps the copy readable against the animated background while
+   still feeling airy and outside the chat shell. */
+.hero-copy {
+  position: relative;
+}
+
+.hero-copy::before {
+  content: "";
+  position: absolute;
+  inset: -12% 12% auto;
+  height: clamp(160px, 24vw, 280px);
+  border-radius: 9999px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.18) 0%,
+    rgba(164, 244, 255, 0.1) 36%,
+    rgba(255, 255, 255, 0) 72%
+  );
+  filter: blur(16px);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.aurora-button {
   background: linear-gradient(
     135deg,
     rgba(255, 255, 255, 0.95),
@@ -747,16 +772,16 @@
   box-shadow:
     0 14px 32px rgba(8, 47, 73, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.86);
+}
 
-  &:hover {
-    background: linear-gradient(135deg, #ffffff, #d9fbff 45%, #fff0a8);
-  }
+.aurora-button:hover {
+  background: linear-gradient(135deg, #ffffff, #d9fbff 45%, #fff0a8);
 }
 
 /* Example prompts: intentionally readable affordance cards (these SHOULD pop
    slightly so users see them as the primary CTA). Kept lightweight: single
    translucent fill + accent stripe, no second backdrop-filter. */
-@utility prompt-glass {
+.prompt-glass {
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(210, 236, 255, 0.5);
@@ -769,14 +794,37 @@
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.36),
     0 0 0 1px rgba(125, 211, 252, 0.12);
+}
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 4px;
-    background: linear-gradient(180deg, #22d3ee, #a78bfa 52%, #facc15);
-  }
+.prompt-glass::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: linear-gradient(180deg, #22d3ee, #a78bfa 52%, #facc15);
+}
+
+.prompt-glass--user::before {
+  inset: 0 0 0 auto;
+}
+
+/* User-message bubble: COMPOSER TWIN. Same gradient, same border, same family
+   — both are "user voice." Subtler glow (no large outer halo) since the
+   bubble is past-input, not active-input. Drop shadow removed per request. */
+.prompt-glass.prompt-glass--user {
+  border: 1px solid rgba(160, 220, 255, 0.42);
+  background:
+    linear-gradient(
+      102deg,
+      rgba(17, 37, 92, 0.82),
+      rgba(26, 54, 128, 0.78) 55%,
+      rgba(98, 34, 121, 0.74)
+    ),
+    rgba(9, 20, 61, 0.64);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.26),
+    0 0 0 1px rgba(83, 185, 255, 0.18),
+    0 0 18px rgba(125, 211, 252, 0.2);
 }
 
 /* Composer shares the locked-state input's animated prism ring. Both inputs
@@ -785,7 +833,7 @@
    existing multi-layer glow (cyan + violet + fuchsia halos) stays as the
    outer halo; the static cyan border + 1px outline are replaced by the
    live gradient sweep applied via ::after with mask-composite. */
-@utility composer-shell {
+.composer-shell {
   position: relative;
   isolation: isolate;
   display: flex;
@@ -807,107 +855,106 @@
     0 0 24px rgba(125, 211, 252, 0.42),
     0 0 50px rgba(167, 139, 250, 0.32),
     0 0 90px rgba(217, 70, 239, 0.18);
+}
 
-  /* Animated prism INTERIOR fill — same palette + cadence as the locked-state
-     input. Sits between the dark base and the content. Straight alpha (no
-     blend mode) since overlay was too subtle against the dark backdrop. */
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(
-      120deg,
-      rgba(125, 249, 255, 0.6),
-      rgba(167, 139, 250, 0.6) 32%,
-      rgba(244, 114, 182, 0.6) 58%,
-      rgba(253, 224, 71, 0.5) 82%,
-      rgba(125, 249, 255, 0.6)
-    );
-    background-size: 220% 100%;
-    animation: prism-sweep 6s ease-in-out infinite;
-    pointer-events: none;
-  }
+.composer-shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: linear-gradient(
+    120deg,
+    rgba(125, 249, 255, 0.85),
+    rgba(167, 139, 250, 0.85) 32%,
+    rgba(244, 114, 182, 0.85) 58%,
+    rgba(253, 224, 71, 0.7) 82%,
+    rgba(125, 249, 255, 0.85)
+  );
+  background-size: 220% 100%;
+  animation: prism-sweep 6s ease-in-out infinite;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
 
-  /* Live gradient sweep BORDER via mask-composite. */
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    padding: 1.5px;
-    background: linear-gradient(
-      120deg,
-      rgba(125, 249, 255, 0.85),
-      rgba(167, 139, 250, 0.85) 32%,
-      rgba(244, 114, 182, 0.85) 58%,
-      rgba(253, 224, 71, 0.7) 82%,
-      rgba(125, 249, 255, 0.85)
-    );
-    background-size: 220% 100%;
-    animation: prism-sweep 6s ease-in-out infinite;
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
-  }
+/* Animated prism INTERIOR fill — same palette + cadence as the locked-state
+   input. Sits between the dark base and the content. Straight alpha (no
+   blend mode) since overlay was too subtle against the dark backdrop. */
+.composer-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    120deg,
+    rgba(125, 249, 255, 0.6),
+    rgba(167, 139, 250, 0.6) 32%,
+    rgba(244, 114, 182, 0.6) 58%,
+    rgba(253, 224, 71, 0.5) 82%,
+    rgba(125, 249, 255, 0.6)
+  );
+  background-size: 220% 100%;
+  animation: prism-sweep 6s ease-in-out infinite;
+  pointer-events: none;
+}
 
-  /* Children sit above the prism-fill ::before so text remains crisp.
-     `:not(.sr-only)` excludes the visually-hidden Label element which relies
-     on `position: absolute` from .sr-only — overriding it back to `relative`
-     made the label a grid item and broke the composer column layout. */
-  & > :not(.sr-only) {
-    position: relative;
-    z-index: 1;
-  }
+/* Children sit above the prism-fill ::before so text remains crisp.
+   `:not(.sr-only)` excludes the visually-hidden Label element which relies
+   on `position: absolute` from .sr-only — overriding it back to `relative`
+   made the label a grid item and broke the composer column layout. */
+.composer-shell > :not(.sr-only) {
+  position: relative;
+  z-index: 1;
 }
 
 /* Header row — typography-first, no container weight. A 1.5px gradient
    hairline beneath it cleanly separates the header from the conversation
    surface. Apple-style: presence via subtle structure, not chunky bars. */
-@utility chat-header {
+.chat-header {
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   padding-bottom: 1rem;
-
-  &::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 1.5px;
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      rgba(125, 249, 255, 0.7) 16%,
-      rgba(167, 139, 250, 0.88) 50%,
-      rgba(244, 114, 182, 0.7) 84%,
-      transparent 100%
-    );
-    box-shadow:
-      0 0 8px rgba(167, 139, 250, 0.35),
-      0 0 16px rgba(125, 249, 255, 0.18);
-    pointer-events: none;
-  }
 }
 
-@utility composer-field {
+.chat-header::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1.5px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(125, 249, 255, 0.7) 16%,
+    rgba(167, 139, 250, 0.88) 50%,
+    rgba(244, 114, 182, 0.7) 84%,
+    transparent 100%
+  );
+  box-shadow:
+    0 0 8px rgba(167, 139, 250, 0.35),
+    0 0 16px rgba(125, 249, 255, 0.18);
+  pointer-events: none;
+}
+
+.composer-field {
   display: block;
   flex: 1 1 0;
   min-width: 0;
   line-height: 1.35;
 }
 
-@utility composer-tools {
+.composer-tools {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
@@ -916,7 +963,7 @@
   padding-right: 0.08rem;
 }
 
-@utility composer-magic {
+.composer-magic {
   display: inline-flex;
   height: 2rem;
   width: 2rem;
@@ -931,15 +978,15 @@
     transform 180ms ease,
     color 180ms ease,
     filter 180ms ease;
-
-  &:hover {
-    transform: scale(1.08);
-    color: rgba(245, 250, 255, 1);
-    filter: drop-shadow(0 0 10px rgba(147, 197, 253, 0.85));
-  }
 }
 
-@utility composer-send {
+.composer-magic:hover {
+  transform: scale(1.08);
+  color: rgba(245, 250, 255, 1);
+  filter: drop-shadow(0 0 10px rgba(147, 197, 253, 0.85));
+}
+
+.composer-send {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -955,46 +1002,59 @@
     0 0 0 1px rgba(255, 255, 255, 0.2),
     0 0 22px rgba(217, 70, 239, 0.52),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
-
-  &:disabled {
-    opacity: 0.85;
-  }
 }
 
-@utility chat-scrollbar {
+.composer-send:disabled {
+  opacity: 0.85;
+}
+
+.chat-scrollbar {
   scrollbar-width: none;
+}
 
-  &::-webkit-scrollbar {
-    width: 0;
+.chat-scrollbar::-webkit-scrollbar {
+  width: 0;
+}
+
+.chat-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-scrollbar::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+  transition:
+    background 160ms ease,
+    width 160ms ease;
+}
+
+.chat-scrollbar:hover {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+
+.chat-scrollbar:hover::-webkit-scrollbar {
+  width: 5px;
+}
+
+.chat-scrollbar:hover::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+@keyframes dot-pulse {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.7);
+    opacity: 0.45;
   }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: transparent;
-    border-radius: 999px;
-    transition:
-      background 160ms ease,
-      width 160ms ease;
-  }
-
-  &:hover {
-    scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-
-    &::-webkit-scrollbar {
-      width: 5px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.28);
-    }
+  40% {
+    transform: scale(1);
+    opacity: 1;
   }
 }
 
-@utility thinking-dot {
+.thinking-dot {
   width: 0.46rem;
   height: 0.46rem;
   border-radius: 9999px;
@@ -1002,18 +1062,16 @@
   box-shadow: 0 0 10px rgba(103, 232, 249, 0.6);
   display: inline-block;
   animation: dot-pulse 1s infinite ease-in-out;
-
-  &:nth-child(2) {
-    animation-delay: 120ms;
-  }
-
-  &:nth-child(3) {
-    animation-delay: 220ms;
-  }
 }
 
-/* Accessibility override — kept at top level (outside @layer) so it overrides
-   utility-layer animation declarations. */
+.thinking-dot:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.thinking-dot:nth-child(3) {
+  animation-delay: 220ms;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

Reverts PR #22 (`refactor(frontend): migrate globals.css to Tailwind v4 idiomatic`, commit `40ae410`).

The v4-native `@utility` migration on its own is sound, but it shipped **before** the 10 post-launch polish branches that also modify `globals.css` (#5 glass-shell, #6 conditional-layout, #8 crowd-silhouette, #9 heart-doodles). With the v4-native pattern on main but the polish CSS still on pre-v4 local branches, each polish PR would need pattern-rewrite at merge time — and meanwhile **main lacks the visible polish** (no crowd silhouette, no heart doodles, no expanded chat shell, wordmark image deleted but JSX still requesting it → 404).

This revert lets the 10 polish branches cherry-pick cleanly onto main (they all branched off pre-refactor main). The v4 refactor will be re-applied as a follow-up commit once polish has landed, by cherry-picking `40ae410` against post-polish main and translating any new polish-introduced classes to `@utility`.

## Plan after merge

1. Branch `restore/post-launch-polish` off post-revert main
2. Cherry-pick 10 polish branches in order: #1, #3, #4, #5, #6, #7, #8, #9, #10, #11 (#2 already merged as PR #21)
3. Push + open single PR with 10 atomic commits → review + rebase-merge (or squash, your call)
4. Re-apply v4 refactor as a follow-up PR on now-polished main

## Test plan

- [x] `pnpm typecheck` clean before revert (would re-run post-revert, expected clean — globals.css change is CSS-only)
- [x] `pnpm lint` clean before revert
- [ ] Verify visual restore once polish PR lands

Co-authored-by: Cursor <cursoragent@cursor.com>