### PR TITLE
chore(frontend): approve esbuild postinstall in pnpm workspace

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 onlyBuiltDependencies:
+  - esbuild
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## Summary

Adds `esbuild` to `frontend/pnpm-workspace.yaml`'s `onlyBuiltDependencies` list.

pnpm v10 gates package postinstall scripts behind explicit per-workspace approval as a supply-chain mitigation. esbuild's native-binary fetcher needs to run for the build pipeline (transitive dep via Next.js / Vite). Without this approval, `pnpm install` re-prompts every contributor and CI run.

`sharp` + `unrs-resolver` were already approved on this list — same mechanism.

## Test plan

- [x] `pnpm install` runs without prompting for esbuild approval
- [x] Build pipeline unaffected (esbuild was already executing; this only persists the approval)
- [ ] CI runs clean (verified once merged)

Co-authored-by: Cursor <cursoragent@cursor.com>