### PR TITLE
docs(frontend): document all env vars + flag course-canonical model

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,17 +10,60 @@
 #
 # Or one-liner to generate SESSION_SECRET into a new .env.local:
 #   printf 'SESSION_SECRET=%s\n' "$(openssl rand -base64 48)" > .env.local
+#
+# Authoritative schema: frontend/lib/env.ts
 # ─────────────────────────────────────────────────────────────────────
 
 # REQUIRED in production. Server-side secret that AES-256-GCM-encrypts
 # the user's OpenAI API key before it lands in the session cookie.
 # Generate with:
 #   openssl rand -base64 48
-# Validation rules (enforced once the cookie-security PR lands):
+# Validation rules (enforced at boot in lib/env.ts):
 #   - Dev/test: >= 32 characters
 #   - Production: >= 48 characters AND >= 3 bits/char Shannon entropy
 #     (so you can't ship "aaaaaaaaaaaa..." to prod)
 SESSION_SECRET=
+
+# OPTIONAL. Model name passed to OpenAI's chat completions endpoint.
+# Default (code): "gpt-5" — matches the sibling FastAPI backend (api/index.py)
+#
+# The course-canonical model is gpt-4.1-mini — that's what the AI Maker
+# Space — AI Engineering Challenge course teaches ("Accessing
+# 'gpt-4.1-mini' (ChatGPT) like a developer"). For the course submission
+# deployment, set this to gpt-4.1-mini.
+#
+# Speed vs. depth trade-off:
+#   - gpt-4.1-mini  — course canonical, fast (TTFT <1s, ~3-5s total)
+#   - gpt-4o        — balanced quality + speed
+#   - gpt-4o-mini   — fastest, cheapest, fine for factual Q&A
+#   - gpt-5         — reasoning model, deep but slow (5-30s wait before
+#                     tokens stream); only if you need chain-of-thought depth
+OPENAI_MODEL=
+
+# OPTIONAL. max_completion_tokens passed to OpenAI.
+# Default (code): 1500
+# Reasoning models (gpt-5, o-series) burn hundreds of tokens on internal
+# chain-of-thought BEFORE emitting visible content. A budget too low
+# results in an empty stream and the user-facing error "The assistant
+# returned an empty response." Recommended values by model:
+#   - gpt-4.1-mini / gpt-4o / gpt-4o-mini:  1500  (default is plenty)
+#   - gpt-5 / reasoning:                    4000  (room for reasoning + answer)
+OPENAI_MAX_COMPLETION_TOKENS=
+
+# OPTIONAL. Upstash REST URL for /api/chat sliding-window rate limiting.
+# When BOTH KV_REST_API_URL and KV_REST_API_TOKEN are set, the chat
+# route enforces 20 req/min/IP via Upstash Redis (state shared across
+# function instances). Absence triggers the per-instance in-memory
+# fallback with a loud production warning — safe for single-instance
+# dev, NOT safe for autoscaled serverless.
+#
+# Easiest setup: Vercel dashboard → Storage → Marketplace → Upstash
+# (sets these auto-named variables for you, no custom prefix).
+KV_REST_API_URL=
+
+# OPTIONAL. Pair with KV_REST_API_URL above. Same Upstash integration
+# sets this auto-named variable.
+KV_REST_API_TOKEN=
 
 # OPTIONAL. Public URL of the Pond5 "Aerophonia" track on Vercel Blob.
 # Format: https://[storeId].public.blob.vercel-storage.com/aerophonia-full-[hash].mp3

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -181,12 +181,16 @@ Plain English. Each link points at the code.
 4. **Production Branch** → `main`
 5. **Environment Variables** (set on both Production AND Preview):
 
-| Var | Value |
-|---|---|
-| `SESSION_SECRET` | `openssl rand -base64 48` (NEW value, distinct from local) |
-| `BLOB_AUDIO_AEROPHONIA_URL` | full Vercel Blob URL of your licensed audio |
-| `KV_REST_API_URL` | auto-set when you connect Upstash from **Storage → Marketplace** with no custom prefix |
-| `KV_REST_API_TOKEN` | auto-set by the same Upstash integration |
+| Var | Required? | Value |
+|---|---|---|
+| `SESSION_SECRET` | **Yes** | `openssl rand -base64 48` (NEW value, distinct from local) |
+| `OPENAI_MODEL` | No (defaults to `gpt-5`) | **`gpt-4.1-mini`** for the course-canonical configuration (see [Things that look weird on purpose](#things-that-look-weird-on-purpose) for the trade-off vs the `gpt-5` default) |
+| `OPENAI_MAX_COMPLETION_TOKENS` | No (defaults to `1500`) | `1500` is fine for `gpt-4.1-mini` (no reasoning overhead). Bump to `4000` if using `gpt-5` so reasoning has room without exhausting the budget mid-answer. |
+| `BLOB_AUDIO_AEROPHONIA_URL` | No | Full Vercel Blob URL of your licensed audio |
+| `KV_REST_API_URL` | No | Auto-set when you connect Upstash from **Storage → Marketplace** with no custom prefix |
+| `KV_REST_API_TOKEN` | No | Auto-set by the same Upstash integration |
+
+> **Authoritative schema:** [`lib/env.ts`](lib/env.ts) — boot-time zod validation, fails loud at startup rather than silently at first request.
 
 6. Click Deploy
 
@@ -245,7 +249,7 @@ The shell is one card. It glows. It has personality.
 - **`<meta name="robots" content="noindex,nofollow">`** in [`app/layout.tsx`](app/layout.tsx) + `Disallow: /` in [`public/robots.txt`](public/robots.txt). Intentional. Non-commercial educational use of Coldplay brand IP under fair use; allowing search-engine indexing would risk brand-confusion concerns. Lighthouse drops SEO to ~63 because of this — by design, not a regression.
 - **The in-memory rate limiter falls back from Upstash when env vars are missing**, with a loud production warning. Single-instance hobby deployments are fine; autoscaled serverless absolutely is not. The warning makes the gap visible in logs.
 - **Audio starts on the *first* user gesture** because browsers refuse `play()` outside one. The cyan-glow "Turn on sound for the full experience" pill on the locked card is the contract: it warns sound is coming; clicking Verify is the gesture that unlocks the crowd track.
-- **`gpt-5` is the default model** because that's what the sibling FastAPI backend uses. Override via `OPENAI_MODEL` if you want `gpt-4o-mini` or anything else — see [`lib/env.ts`](lib/env.ts).
+- **`gpt-5` is the code default model** because that matches the sibling FastAPI backend ([`api/index.py:37`](../api/index.py)). But `gpt-5` is a reasoning model — it runs silent chain-of-thought before emitting any visible tokens (5-30s wait before content streams), and if `OPENAI_MAX_COMPLETION_TOKENS` is too low the reasoning eats the entire budget and the user gets an empty response. **The course-canonical model is `gpt-4.1-mini`** — that's what the [AI Maker Space — AI Engineering Challenge](https://github.com/AI-Maker-Space/The-AI-Engineer-Challenge) course teaches ("*Accessing 'gpt-4.1-mini' (ChatGPT) like a developer*"). For the course submission deployment, set `OPENAI_MODEL=gpt-4.1-mini` in Vercel — fast (TTFT <1s, ~3-5s end-to-end), no reasoning overhead, and the `OPENAI_MAX_COMPLETION_TOKENS` default of `1500` is plenty. The empty-response incident this surfaced is documented in [`lib/env.ts`](lib/env.ts) lines 43-49.
 - **The disclaimer paragraph at the bottom of the page is not boilerplate.** It exists because this project uses the *Coldplay* name nominatively — describing the subject of the chat, not implying any affiliation. The same goes for the `Audio Credits` block listing Pond5 / TangerineMedia properly.
 
 ---


### PR DESCRIPTION
## Summary

Two documentation gaps surfaced by today's production incident (the `OPENAI_MAX_COMPLETION_TOKENS` empty-response error and the slow `gpt-5` reasoning UX):

1. **`.env.example`** was missing 4 of the 7 env vars the code actually reads in `lib/env.ts`: `OPENAI_MODEL`, `OPENAI_MAX_COMPLETION_TOKENS`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`. Now documented inline with defaults, when to set them, and recommended values per model.

2. **README's deploy env-var table** was missing the two OPENAI_* variables, and the "things that look weird on purpose" note on the `gpt-5` default didn't mention that it's a reasoning model with high time-to-first-token — the exact failure mode that produced today's empty-response error.

## Course-canonical model called out explicitly

The [AI Maker Space — AI Engineering Challenge](https://github.com/AI-Maker-Space/The-AI-Engineer-Challenge) course teaches **`gpt-4.1-mini`** ("*Accessing 'gpt-4.1-mini' (ChatGPT) like a developer*"). The deploy table now recommends `OPENAI_MODEL=gpt-4.1-mini` for the course submission configuration — fast (TTFT <1s, ~3-5s total), no reasoning overhead, and the default `OPENAI_MAX_COMPLETION_TOKENS` of 1500 is plenty for it.

The **code default** stays at `gpt-5` to preserve parity with the sibling FastAPI backend (`api/index.py:37`). The README explicitly documents this asymmetry and the trade-off.

## No code change

Pure documentation alignment with what `lib/env.ts` already validates at boot. Zero behavior change.

## Test plan

- [x] `.env.example` covers all 7 env vars in `serverEnvSchema`
- [x] README deploy table lists all configurable env vars + required/optional + when to use
- [x] "Things that look weird on purpose" note on `gpt-5` model explains the reasoning-model trade-off + points at `gpt-4.1-mini` as the course-canonical choice
- [x] No stray references to wrong model names (verified by grep)

Co-authored-by: Cursor <cursoragent@cursor.com>