### PR TITLE
refactor(frontend): migrate globals.css to Tailwind v4 idiomatic

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,10 +3,13 @@
 
 /* ─────────────────────────────────────────────────────────────────────────
    Design tokens — Tailwind v4 @theme directive.
-   Every `--color-*` token below is auto-exposed as a Tailwind utility:
-     bg-bg-warm, text-aurora-cyan, border-glass-border, fill-signal-success, …
-   The token names follow the Tailwind v4 convention so they integrate with
-   the rest of the framework (variants, modifiers, color-mix, etc.).
+
+   Color tokens auto-expose as Tailwind utilities (bg-bg-warm, text-aurora-cyan,
+   border-glass-border, etc.) following the v4 namespace convention.
+
+   Animation tokens (--animate-*) each emit a corresponding `animate-{name}`
+   utility class. @keyframes definitions live inside @theme alongside their
+   tokens (per Tailwind v4 docs: "Animation Registration with @keyframes").
    ───────────────────────────────────────────────────────────────────────── */
 @theme {
   /* Cinematic vignette — daylight center, indigo deepening at edges. */
@@ -37,12 +40,30 @@
   --color-signal-error: #fb7185;
   --color-signal-warn: #fbbf24;
 
-  /* Crowd silhouette animations — registered as v4 animation utilities so
-     `animate-crowd-*` are first-class Tailwind classes. The two PNGs
-     cross-fade on a 12s loop while the inner stack subtly bobs. */
+  /* Animation tokens — every keyframe registered as a Tailwind utility.
+     `animate-crowd-{bob,fade-a,fade-b}` are actively consumed by
+     `crowd-silhouette.tsx`. The rest are forward-compat — future JSX can
+     opt into `animate-prism-sweep`, `animate-panel-in`, etc. without
+     re-touching this file. Unused tokens tree-shake at build time. */
   --animate-crowd-bob: crowd-bob 12s ease-in-out infinite;
   --animate-crowd-fade-a: crowd-fade-a 12s ease-in-out infinite;
   --animate-crowd-fade-b: crowd-fade-b 12s ease-in-out infinite;
+  --animate-rainbow-drift-a: rainbow-drift-a 12s ease-in-out infinite alternate;
+  --animate-rainbow-drift-d: rainbow-drift-d 15s ease-in-out infinite alternate;
+  --animate-aurora-particles-drift: aurora-particles-drift 60s linear infinite alternate;
+  --animate-aurora-pill-breathe: aurora-pill-breathe 4.5s ease-in-out infinite;
+  --animate-aurora-pill-sweep: aurora-pill-sweep 9s ease-in-out infinite;
+  --animate-status-dot-pulse: status-dot-pulse 2s ease-in-out infinite;
+  --animate-prism-sweep: prism-sweep 8s ease-in-out infinite;
+  --animate-panel-in: panel-in 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  --animate-panel-out: panel-out 180ms cubic-bezier(0.4, 0, 1, 1) both;
+  --animate-shell-burst-glow: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
+  --animate-shell-aurora-drift: shell-aurora-drift 16s ease-in-out infinite alternate;
+  --animate-avatar-aurora-spin: avatar-aurora-spin 7s linear infinite;
+  --animate-avatar-aurora-breathe: avatar-aurora-breathe 3.4s ease-in-out infinite;
+  --animate-dot-pulse: dot-pulse 1s ease-in-out infinite;
+
+  /* Keyframes — paired with their --animate-* token above. */
 
   @keyframes crowd-bob {
     0%,
@@ -81,106 +102,325 @@
       opacity: 0;
     }
   }
-}
 
-:root {
-  color-scheme: dark;
+  @keyframes rainbow-drift-a {
+    from {
+      transform: translate3d(-3%, -1.5%, 0) scale(1.01);
+    }
+    to {
+      transform: translate3d(6%, 4.5%, 0) scale(1.05);
+    }
+  }
 
-  /* Chat shell heights — drive the locked → unlocked expansion animation.
-     Kept in `:root` (not `@theme`) because Tailwind v4 doesn't have a height
-     namespace; consumed via `var(...)` in the `.chat-shell-frame` rule. */
-  --shell-h-locked: clamp(320px, 44svh, 380px);
-  --shell-h-unlocked: 72svh;
-  --shell-max-h-unlocked: 820px;
-}
+  @keyframes rainbow-drift-d {
+    from {
+      transform: translate3d(2%, 2%, 0) scale(1.01);
+    }
+    to {
+      transform: translate3d(-6.5%, -5.5%, 0) scale(1.06);
+    }
+  }
 
-@media (min-width: 640px) {
-  :root {
-    --shell-h-locked: clamp(340px, 42svh, 400px);
-    --shell-h-unlocked: 74svh;
+  @keyframes aurora-particles-drift {
+    from {
+      transform: translate3d(0, 0, 0);
+    }
+    to {
+      transform: translate3d(2.4%, -1.4%, 0);
+    }
+  }
+
+  @keyframes aurora-pill-breathe {
+    0%,
+    100% {
+      box-shadow:
+        0 0 12px rgba(167, 139, 250, 0.28),
+        0 0 24px rgba(125, 249, 255, 0.14);
+    }
+    50% {
+      box-shadow:
+        0 0 18px rgba(167, 139, 250, 0.48),
+        0 0 38px rgba(125, 249, 255, 0.24);
+    }
+  }
+
+  @keyframes aurora-pill-sweep {
+    0%,
+    100% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+  }
+
+  @keyframes status-dot-pulse {
+    0%,
+    100% {
+      box-shadow:
+        0 0 6px rgba(110, 231, 183, 0.7),
+        0 0 0 0 rgba(110, 231, 183, 0);
+      transform: scale(1);
+    }
+    50% {
+      box-shadow:
+        0 0 14px rgba(110, 231, 183, 1),
+        0 0 22px rgba(110, 231, 183, 0.55);
+      transform: scale(1.14);
+    }
+  }
+
+  @keyframes prism-sweep {
+    0%,
+    100% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+  }
+
+  @keyframes panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.99);
+      filter: blur(3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      filter: blur(0);
+    }
+  }
+
+  @keyframes panel-out {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      filter: blur(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-6px) scale(0.995);
+      filter: blur(2px);
+    }
+  }
+
+  @keyframes shell-burst-glow {
+    0% {
+      box-shadow:
+        0 22px 56px rgba(2, 8, 28, 0.42),
+        0 6px 18px rgba(2, 8, 28, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    }
+    35% {
+      box-shadow:
+        0 22px 56px rgba(2, 8, 28, 0.42),
+        0 6px 18px rgba(2, 8, 28, 0.24),
+        0 0 60px rgba(125, 249, 255, 0.55),
+        0 0 110px rgba(167, 139, 250, 0.4),
+        0 0 180px rgba(244, 114, 182, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.36);
+    }
+    100% {
+      box-shadow:
+        0 22px 56px rgba(2, 8, 28, 0.42),
+        0 6px 18px rgba(2, 8, 28, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    }
+  }
+
+  @keyframes shell-aurora-drift {
+    0% {
+      transform: translate3d(0, 0, 0) scale(1);
+      opacity: 0.78;
+    }
+    50% {
+      transform: translate3d(3.4%, -2.6%, 0) scale(1.08);
+      opacity: 1;
+    }
+    100% {
+      transform: translate3d(-3%, 3.2%, 0) scale(1.04);
+      opacity: 0.86;
+    }
+  }
+
+  @keyframes avatar-aurora-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes avatar-aurora-breathe {
+    0%,
+    100% {
+      opacity: 0.55;
+      filter: blur(6px);
+    }
+    50% {
+      opacity: 1;
+      filter: blur(10px);
+    }
+  }
+
+  @keyframes dot-pulse {
+    0%,
+    80%,
+    100% {
+      transform: scale(0.7);
+      opacity: 0.45;
+    }
+    40% {
+      transform: scale(1);
+      opacity: 1;
+    }
   }
 }
 
-@media (min-width: 1024px) {
+/* ─────────────────────────────────────────────────────────────────────────
+   Base layer — runs alongside Tailwind v4 Preflight per @layer ordering.
+   See: https://tailwindcss.com/docs/preflight (Extending Preflight).
+   ───────────────────────────────────────────────────────────────────────── */
+@layer base {
   :root {
-    --shell-h-locked: clamp(360px, 40svh, 440px);
-    --shell-h-unlocked: 88svh;
-    --shell-max-h-unlocked: 960px;
+    color-scheme: dark;
+
+    /* Chat shell heights — drive the locked → unlocked expansion animation.
+       Kept in `:root` (not `@theme`) because Tailwind v4 has no `height`
+       namespace; consumed via `var(...)` in the .chat-shell-frame @utility. */
+    --shell-h-locked: clamp(320px, 44svh, 380px);
+    --shell-h-unlocked: 72svh;
+    --shell-max-h-unlocked: 820px;
+  }
+
+  @media (min-width: 640px) {
+    :root {
+      --shell-h-locked: clamp(340px, 42svh, 400px);
+      --shell-h-unlocked: 74svh;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    :root {
+      --shell-h-locked: clamp(360px, 40svh, 440px);
+      --shell-h-unlocked: 88svh;
+      --shell-max-h-unlocked: 960px;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    :root {
+      --shell-h-locked: clamp(380px, 42svh, 460px);
+      --shell-h-unlocked: 90svh;
+      --shell-max-h-unlocked: 1020px;
+    }
+  }
+
+  @media (min-width: 1536px) {
+    :root {
+      --shell-h-locked: clamp(400px, 44svh, 480px);
+      --shell-max-h-unlocked: 1080px;
+    }
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    min-height: 100%;
+    font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--color-text-primary);
+    /* Cinematic vignette: daylight center where the hero + chat live, indigo
+       deepening toward the edges. Aurora blobs add diffuse rainbow glow that
+       compounds with the rainbow SVG layers above. */
+    background:
+      radial-gradient(circle at 18% 18%, var(--color-aurora-cyan), transparent 34%),
+      radial-gradient(circle at 86% 15%, var(--color-aurora-magenta), transparent 36%),
+      radial-gradient(circle at 48% 88%, var(--color-aurora-amber), transparent 38%),
+      radial-gradient(
+        ellipse 95% 75% at 50% 38%,
+        var(--color-bg-warm) 0%,
+        var(--color-bg-mid) 38%,
+        var(--color-bg-deep) 68%,
+        var(--color-bg-edge-indigo) 88%,
+        var(--color-bg-edge-deep) 100%
+      );
+    background-attachment: fixed;
+    cursor:
+      url("https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766") 16 16,
+      auto;
+  }
+
+  /* Clickable surfaces show the standard OS pointer, not the heart, so the
+     user can tell at a glance what is interactive vs. decorative. */
+  a,
+  button,
+  [role="button"],
+  [type="submit"],
+  [type="button"],
+  label[for] {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"],
+  button[aria-disabled="true"] {
+    cursor: not-allowed;
+  }
+
+  input,
+  textarea {
+    cursor: text;
+  }
+
+  /* Accessibility primitive — kept in @layer base (not @utility) because
+     it's a semantic visually-hidden helper, not a composable design utility. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Conditional layout — body[data-chat-locked] is set by a useEffect inside
+     ChatShell. CSS targets it via a plain descendant selector (no :has()
+     dependency, which proved unreliable in some browser/Tailwind v4 combos).
+     Locked → flex column centers vertically as a single group.
+     Unlocked → disclaimer wrapper gets margin-top: auto to pin to viewport
+     bottom; chat shell expands to fill the upper area. */
+  @media (min-width: 1024px) {
+    body[data-chat-locked="false"] [data-disclaimer-wrapper] {
+      margin-top: auto;
+    }
+    body[data-chat-locked="true"] [data-layout-root] {
+      justify-content: center;
+    }
   }
 }
 
-@media (min-width: 1280px) {
-  :root {
-    --shell-h-locked: clamp(380px, 42svh, 460px);
-    --shell-h-unlocked: 90svh;
-    --shell-max-h-unlocked: 1020px;
-  }
-}
-
-@media (min-width: 1536px) {
-  :root {
-    --shell-h-locked: clamp(400px, 44svh, 480px);
-    --shell-max-h-unlocked: 1080px;
-  }
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-  font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  color: var(--color-text-primary);
-  /* Cinematic vignette: daylight center where the hero + chat live, indigo
-     deepening toward the edges. The vignette funnels the eye inward without
-     darkening the reading zone. Aurora blobs add diffuse rainbow glow that
-     compounds with the rainbow SVG layers above. */
-  background:
-    radial-gradient(circle at 18% 18%, var(--color-aurora-cyan), transparent 34%),
-    radial-gradient(circle at 86% 15%, var(--color-aurora-magenta), transparent 36%),
-    radial-gradient(circle at 48% 88%, var(--color-aurora-amber), transparent 38%),
-    radial-gradient(
-      ellipse 95% 75% at 50% 38%,
-      var(--color-bg-warm) 0%,
-      var(--color-bg-mid) 38%,
-      var(--color-bg-deep) 68%,
-      var(--color-bg-edge-indigo) 88%,
-      var(--color-bg-edge-deep) 100%
-    );
-  background-attachment: fixed;
-  cursor:
-    url("https://eustore.coldplay.com/cdn/shop/files/heart_favicon.png?v=1770660766") 16 16,
-    auto;
-}
-
-/* Clickable surfaces show the standard OS pointer, not the heart, so the
-   user can tell at a glance what is interactive vs. decorative. */
-a,
-button,
-[role="button"],
-[type="submit"],
-[type="button"],
-label[for] {
-  cursor: pointer;
-}
-
-button:disabled,
-[role="button"][aria-disabled="true"],
-button[aria-disabled="true"] {
-  cursor: not-allowed;
-}
-
-input,
-textarea {
-  cursor: text;
-}
+/* ─────────────────────────────────────────────────────────────────────────
+   Custom utilities — every former bare-class declaration lifted into v4's
+   @utility directive so they compose with variants (hover:, md:, dark:) and
+   tree-shake when unused. Pseudo-elements (::before, ::after), state
+   modifiers (&[data-state], &:hover, &:disabled), and descendant rules
+   are nested via the & parent reference (Lightning CSS handles native
+   nesting at build time).
+   ───────────────────────────────────────────────────────────────────────── */
 
 /* Coldplay Moon Music style background graphics, layered like the official site. */
-.global-graphics {
+@utility global-graphics {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -188,67 +428,71 @@ textarea {
   overflow: hidden;
   z-index: -1;
   pointer-events: none;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  /* Ambient particle dust — tiny light points drifting slowly across the canvas.
+     Pure CSS (no JS), respects prefers-reduced-motion via the global override
+     below. Adds subliminal "alive" depth without competing with the aurora. */
+  &::before {
+    background:
+      radial-gradient(1.2px 1.2px at 12% 22%, rgba(255, 255, 255, 0.55), transparent 60%),
+      radial-gradient(1.4px 1.4px at 28% 78%, rgba(255, 255, 255, 0.45), transparent 60%),
+      radial-gradient(1px 1px at 48% 14%, rgba(196, 228, 255, 0.5), transparent 60%),
+      radial-gradient(1.6px 1.6px at 64% 64%, rgba(255, 255, 255, 0.45), transparent 60%),
+      radial-gradient(1.2px 1.2px at 82% 32%, rgba(220, 232, 255, 0.55), transparent 60%),
+      radial-gradient(1.4px 1.4px at 92% 86%, rgba(255, 255, 255, 0.4), transparent 60%),
+      radial-gradient(1px 1px at 38% 46%, rgba(255, 255, 255, 0.42), transparent 60%),
+      radial-gradient(1.2px 1.2px at 72% 12%, rgba(220, 240, 255, 0.5), transparent 60%);
+    opacity: 0.7;
+    animation: aurora-particles-drift 60s linear infinite alternate;
+  }
+
+  &::after {
+    background: none;
+    animation: none;
+  }
 }
 
-.global-graphics::before,
-.global-graphics::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-/* Ambient particle dust — tiny light points drifting slowly across the canvas.
-   Pure CSS (no JS), respects prefers-reduced-motion via the global override
-   below. Adds subliminal "alive" depth without competing with the aurora. */
-.global-graphics::before {
-  background:
-    radial-gradient(1.2px 1.2px at 12% 22%, rgba(255, 255, 255, 0.55), transparent 60%),
-    radial-gradient(1.4px 1.4px at 28% 78%, rgba(255, 255, 255, 0.45), transparent 60%),
-    radial-gradient(1px 1px at 48% 14%, rgba(196, 228, 255, 0.5), transparent 60%),
-    radial-gradient(1.6px 1.6px at 64% 64%, rgba(255, 255, 255, 0.45), transparent 60%),
-    radial-gradient(1.2px 1.2px at 82% 32%, rgba(220, 232, 255, 0.55), transparent 60%),
-    radial-gradient(1.4px 1.4px at 92% 86%, rgba(255, 255, 255, 0.4), transparent 60%),
-    radial-gradient(1px 1px at 38% 46%, rgba(255, 255, 255, 0.42), transparent 60%),
-    radial-gradient(1.2px 1.2px at 72% 12%, rgba(220, 240, 255, 0.5), transparent 60%);
-  opacity: 0.7;
-  animation: aurora-particles-drift 60s linear infinite alternate;
-}
-
-.global-graphics::after {
-  background: none;
-  animation: none;
-}
-
-.header__bg-img,
-.footer__bg-2-img {
+@utility header__bg-img {
   position: absolute;
   display: block;
   width: clamp(420px, 78vw, 1640px);
   line-height: 0;
-}
+  top: -16%;
+  left: -6%;
+  animation: rainbow-drift-a 12s ease-in-out infinite alternate;
 
-@media (max-width: 640px) {
-  .header__bg-img,
-  .footer__bg-2-img {
+  @media (max-width: 640px) {
     width: clamp(280px, 90vw, 520px);
   }
 }
 
-.header__bg-img {
-  top: -16%;
-  left: -6%;
-  animation: rainbow-drift-a 12s ease-in-out infinite alternate;
-}
-
-.footer__bg-2-img {
+@utility footer__bg-2-img {
+  position: absolute;
+  display: block;
+  width: clamp(420px, 78vw, 1640px);
+  line-height: 0;
   bottom: -8%;
   right: -6%;
   animation: rainbow-drift-d 15s ease-in-out infinite alternate;
+
+  @media (max-width: 640px) {
+    width: clamp(280px, 90vw, 520px);
+  }
+
+  & .footer__bg {
+    transform: scaleX(-1);
+  }
 }
 
-.header__bg,
-.footer__bg {
+@utility header__bg {
   display: block;
   width: 100%;
   height: auto;
@@ -259,53 +503,19 @@ textarea {
   filter: saturate(1.55) contrast(1.08) brightness(1.04);
 }
 
-.footer__bg-2-img .footer__bg {
-  transform: scaleX(-1);
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-@keyframes rainbow-drift-a {
-  from {
-    transform: translate3d(-3%, -1.5%, 0) scale(1.01);
-  }
-  to {
-    transform: translate3d(6%, 4.5%, 0) scale(1.05);
-  }
-}
-
-@keyframes rainbow-drift-d {
-  from {
-    transform: translate3d(2%, 2%, 0) scale(1.01);
-  }
-  to {
-    transform: translate3d(-6.5%, -5.5%, 0) scale(1.06);
-  }
-}
-
-@keyframes aurora-particles-drift {
-  from {
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    transform: translate3d(2.4%, -1.4%, 0);
-  }
+@utility footer__bg {
+  display: block;
+  width: 100%;
+  height: auto;
+  opacity: 1;
+  mix-blend-mode: screen;
+  filter: saturate(1.55) contrast(1.08) brightness(1.04);
 }
 
 /* Aurora pill — gradient-bordered label with a soft breathing outer glow.
    Connects every "chrome label" (hero pill, status pill) to the prism
    palette without stealing focus from the chat content. */
-.aurora-pill {
+@utility aurora-pill {
   position: relative;
   isolation: isolate;
   background: rgba(255, 255, 255, 0.08);
@@ -313,94 +523,44 @@ textarea {
     0 0 12px rgba(167, 139, 250, 0.28),
     0 0 24px rgba(125, 249, 255, 0.14);
   animation: aurora-pill-breathe 4.5s ease-in-out infinite;
-}
 
-.aurora-pill::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(
-    120deg,
-    rgba(125, 249, 255, 0.85),
-    rgba(167, 139, 250, 0.85) 38%,
-    rgba(244, 113, 181, 0.85) 68%,
-    rgba(253, 224, 71, 0.7)
-  );
-  background-size: 220% 100%;
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-  animation: aurora-pill-sweep 9s ease-in-out infinite;
-}
-
-@keyframes aurora-pill-breathe {
-  0%,
-  100% {
-    box-shadow:
-      0 0 12px rgba(167, 139, 250, 0.28),
-      0 0 24px rgba(125, 249, 255, 0.14);
-  }
-  50% {
-    box-shadow:
-      0 0 18px rgba(167, 139, 250, 0.48),
-      0 0 38px rgba(125, 249, 255, 0.24);
-  }
-}
-
-@keyframes aurora-pill-sweep {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      120deg,
+      rgba(125, 249, 255, 0.85),
+      rgba(167, 139, 250, 0.85) 38%,
+      rgba(244, 113, 181, 0.85) 68%,
+      rgba(253, 224, 71, 0.7)
+    );
+    background-size: 220% 100%;
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    animation: aurora-pill-sweep 9s ease-in-out infinite;
   }
 }
 
 /* Live connection status dot — soft breathing pulse signals "the AI is
    reachable right now." 2s cycle stays calm; double-shadow gives a halo. */
-.status-dot-live {
+@utility status-dot-live {
   animation: status-dot-pulse 2s ease-in-out infinite;
-}
-
-@keyframes status-dot-pulse {
-  0%,
-  100% {
-    box-shadow:
-      0 0 6px rgba(110, 231, 183, 0.7),
-      0 0 0 0 rgba(110, 231, 183, 0);
-    transform: scale(1);
-  }
-  50% {
-    box-shadow:
-      0 0 14px rgba(110, 231, 183, 1),
-      0 0 22px rgba(110, 231, 183, 0.55);
-    transform: scale(1.14);
-  }
 }
 
 /* Prism line — the app's signature element. A thin gradient bar under the
    hero H1 with a slow sweeping animation. Echoes Coldplay's prism motif
    without copying any specific brand mark. Becomes the visual fingerprint. */
-@keyframes prism-sweep {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-.prism-line {
+@utility prism-line {
   display: block;
   height: 1.5px;
   width: clamp(220px, 28vw, 360px);
@@ -424,7 +584,7 @@ textarea {
 }
 
 /* Reusable gradient hairline — used for chat-header divider and page-bottom divider. */
-.gradient-hairline {
+@utility gradient-hairline {
   height: 1.5px;
   background: linear-gradient(
     90deg,
@@ -439,90 +599,11 @@ textarea {
     0 0 16px rgba(125, 249, 255, 0.18);
 }
 
-@keyframes global-canvas-drift {
-  from {
-    transform: translate3d(-1.2%, 0.8%, 0) scale(1.01);
-    filter: saturate(1.02);
-  }
-  to {
-    transform: translate3d(1.4%, -1.1%, 0) scale(1.04);
-    filter: saturate(1.12);
-  }
-}
-
-@keyframes page-aurora-flow {
-  from {
-    background-position:
-      0% 0%,
-      100% 0%,
-      50% 100%,
-      0% 0%;
-    filter: saturate(1);
-  }
-  to {
-    background-position:
-      24% -16%,
-      72% 18%,
-      34% 86%,
-      0% 0%;
-    filter: saturate(1.12);
-  }
-}
-
-@keyframes ambient-glow-drift {
-  from {
-    transform: translate3d(-1.2%, 0.5%, 0) scale(1);
-    opacity: 0.92;
-  }
-  to {
-    transform: translate3d(1.4%, -0.8%, 0) scale(1.03);
-    opacity: 1;
-  }
-}
-
-@keyframes ambient-vignette-pulse {
-  0%,
-  100% {
-    opacity: 0.9;
-    filter: saturate(1);
-  }
-  50% {
-    opacity: 1;
-    filter: saturate(1.08);
-  }
-}
-
-@keyframes panel-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.99);
-    filter: blur(3px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-    filter: blur(0);
-  }
-}
-
-@keyframes panel-out {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-    filter: blur(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-6px) scale(0.995);
-    filter: blur(2px);
-  }
-}
-
-.panel-enter {
+@utility panel-enter {
   animation: panel-in 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
-.panel-exit {
+@utility panel-exit {
   animation: panel-out 180ms cubic-bezier(0.4, 0, 1, 1) both;
 }
 
@@ -530,7 +611,7 @@ textarea {
    heights using a soft spring curve. The parent flex column is justify-center,
    so as height changes the shell visually expands/contracts from its vertical
    center (both up and down simultaneously). */
-.chat-shell-frame {
+@utility chat-shell-frame {
   display: flex;
   align-items: stretch;
   height: var(--shell-h-unlocked);
@@ -538,59 +619,35 @@ textarea {
   transition:
     height 720ms cubic-bezier(0.34, 1.42, 0.55, 1),
     max-height 720ms cubic-bezier(0.34, 1.42, 0.55, 1);
-}
 
-.chat-shell-frame[data-state="locked"] {
-  height: var(--shell-h-locked);
-  max-height: var(--shell-h-locked);
-}
+  &[data-state="locked"] {
+    height: var(--shell-h-locked);
+    max-height: var(--shell-h-locked);
 
-/* One-shot glow burst — fires whenever the shell flips locked↔unlocked.
-   The 900ms cyan/violet halo flash makes the height transition feel
-   *magical* rather than mechanical; users see and feel the moment. */
-.chat-shell-frame.shell-burst .chat-shell-glass {
-  animation: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
-}
-
-@keyframes shell-burst-glow {
-  0% {
-    box-shadow:
-      0 22px 56px rgba(2, 8, 28, 0.42),
-      0 6px 18px rgba(2, 8, 28, 0.24),
-      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    /* Locked-state aurora bump — when the shell is in locked mode, the inner
+       aurora glow runs warmer + faster to make the compact card feel focused
+       and lit. Reverts to baseline on unlock. */
+    & .chat-shell-glass::after {
+      background:
+        radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.4), transparent 62%),
+        radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.36), transparent 62%),
+        radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.32), transparent 62%);
+      animation-duration: 12s;
+    }
   }
-  35% {
-    box-shadow:
-      0 22px 56px rgba(2, 8, 28, 0.42),
-      0 6px 18px rgba(2, 8, 28, 0.24),
-      0 0 60px rgba(125, 249, 255, 0.55),
-      0 0 110px rgba(167, 139, 250, 0.4),
-      0 0 180px rgba(244, 114, 182, 0.2),
-      inset 0 1px 0 rgba(255, 255, 255, 0.36);
-  }
-  100% {
-    box-shadow:
-      0 22px 56px rgba(2, 8, 28, 0.42),
-      0 6px 18px rgba(2, 8, 28, 0.24),
-      inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  }
-}
 
-/* Locked-state aurora bump — when the shell is in locked mode, the inner
-   aurora glow runs warmer + faster to make the compact card feel focused
-   and lit. Reverts to baseline on unlock. */
-.chat-shell-frame[data-state="locked"] .chat-shell-glass::after {
-  background:
-    radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.4), transparent 62%),
-    radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.36), transparent 62%),
-    radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.32), transparent 62%);
-  animation-duration: 12s;
+  /* One-shot glow burst — fires whenever the shell flips locked↔unlocked.
+     The 900ms cyan/violet halo flash makes the height transition feel
+     *magical* rather than mechanical; users see and feel the moment. */
+  &.shell-burst .chat-shell-glass {
+    animation: shell-burst-glow 900ms cubic-bezier(0.34, 1.42, 0.55, 1);
+  }
 }
 
 /* Animated gradient ring around the locked-state input. Uses the prism
    palette — cohesive with the prism line, hero "Coldplay" gradient, and
    the lit eyebrow. Cyan → violet → fuchsia → amber → cyan sweep. */
-.locked-input-ring {
+@utility locked-input-ring {
   position: relative;
   isolation: isolate;
   border-radius: 0.5rem;
@@ -608,17 +665,17 @@ textarea {
   box-shadow:
     0 0 14px rgba(167, 139, 250, 0.4),
     0 0 28px rgba(125, 249, 255, 0.22);
-}
 
-.locked-input-ring > * {
-  border-radius: calc(0.5rem - 1px);
+  & > * {
+    border-radius: calc(0.5rem - 1px);
+  }
 }
 
 /* Verify-button interior — wrapped in `.locked-input-ring` (the same wrapper
    the Input uses) so the animated prism gradient border + height come from
-   the wrapper. This class just styles the button's interior surface so it
-   reads as a clear CTA against the dark page. */
-.locked-verify-btn {
+   the wrapper. This class just establishes a stacking context for the
+   button's interior surface. */
+@utility locked-verify-btn {
   position: relative;
 }
 
@@ -627,7 +684,7 @@ textarea {
    This is the FAANG/modern-AI-chat pattern: ChatGPT, Claude.ai, Gemini all
    put the conversation in the darkest zone on the page so the bright
    surrounding palette becomes the frame and text contrast is maximal. */
-.chat-shell-glass {
+@utility chat-shell-glass {
   /* `isolation: isolate` creates a clean stacking context WITHOUT breaking
      backdrop-filter the way `opacity:<1` would. Apple uses this pattern on
      macOS Sonoma panels and iOS notifications. The pseudo-elements (::before
@@ -649,7 +706,7 @@ textarea {
      aggressive blue instead of calm tinted glass. */
 
   /* Thicker, more visible glass edge — 2.5px alpha 0.28 reads as a real
-     physical rim, matches the GitHub Copilot reference you shared. */
+     physical rim, matches the GitHub Copilot reference. */
   border: 2.5px solid rgba(255, 255, 255, 0.28);
 
   /* Glow stack — tuned so the AURORA palette leads, white is a tight edge
@@ -671,162 +728,105 @@ textarea {
     0 60px rgba(125, 249, 255, 0.34),
     0 0 110px rgba(167, 139, 250, 0.3),
     0 0 180px rgba(244, 114, 182, 0.2);
-}
 
-/* Subtle top-down sheen, gives the glass its "lit edge" highlight. */
-.chat-shell-glass::before {
   /* Top-edge sheen — the "lit lens" highlight that makes a translucent panel
      read as physical glass under a soft light source. Linear 180deg gradient
      fading from a subtle white wash at the top to fully transparent by 30%
      down. Sits ABOVE the backdrop-filter via the parent's stacking context. */
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 30%);
-}
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 30%);
+  }
 
-/* Inner ambient aurora — cyan/magenta/violet blobs that visibly drift inside
-   the chat shell so the conversation zone feels alive. Higher alpha now
-   (mix-blend-mode was washing the colors out against the white glass) and
-   a faster cycle so the motion actually registers. */
-.chat-shell-glass::after {
   /* Ambient aurora — cyan/magenta/violet blobs that drift inside the shell
      for that "alive surface" feel. Alpha values are intentionally LOWER
-     than the previous design (0.18 / 0.14 / 0.14 vs 0.34 / 0.30 / 0.26)
-     so the underlying frost reads clearly — the colors are a hint, not a
-     wash. No backdrop-filter here: that's the parent's job. */
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background:
-    radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.18), transparent 62%),
-    radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.14), transparent 62%),
-    radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.14), transparent 62%);
-  animation: shell-aurora-drift 16s ease-in-out infinite alternate;
-}
-
-.chat-shell-glass > * {
-  position: relative;
-  z-index: 1;
-}
-
-@keyframes shell-aurora-drift {
-  0% {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 0.78;
+     than the bordering glow stack (0.18 / 0.14 / 0.14) so the underlying
+     frost reads clearly — the colors are a hint, not a wash. No backdrop-
+     filter here: that's the parent's job. */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background:
+      radial-gradient(ellipse 62% 48% at 18% 26%, rgba(125, 249, 255, 0.18), transparent 62%),
+      radial-gradient(ellipse 52% 44% at 86% 70%, rgba(244, 114, 182, 0.14), transparent 62%),
+      radial-gradient(ellipse 58% 42% at 50% 108%, rgba(167, 139, 250, 0.14), transparent 62%);
+    animation: shell-aurora-drift 16s ease-in-out infinite alternate;
   }
-  50% {
-    transform: translate3d(3.4%, -2.6%, 0) scale(1.08);
-    opacity: 1;
-  }
-  100% {
-    transform: translate3d(-3%, 3.2%, 0) scale(1.04);
-    opacity: 0.86;
+
+  & > * {
+    position: relative;
+    z-index: 1;
   }
 }
 
 /* AI avatar focal pulse — a soft aurora ring that breathes around the
    Sparkles avatar. Signals "the AI is alive" with a single focal point of
    motion that the eye naturally tracks during conversation. */
-.ai-avatar-aurora {
+@utility ai-avatar-aurora {
   position: relative;
-}
 
-.ai-avatar-aurora::before {
-  content: "";
-  position: absolute;
-  inset: -4px;
-  border-radius: 9999px;
-  background: conic-gradient(
-    from 0deg,
-    rgba(125, 249, 255, 0.55),
-    rgba(167, 139, 250, 0.55),
-    rgba(244, 114, 182, 0.55),
-    rgba(253, 224, 71, 0.55),
-    rgba(125, 249, 255, 0.55)
-  );
-  filter: blur(7px);
-  z-index: -1;
-  opacity: 0.85;
-  animation:
-    avatar-aurora-spin 7s linear infinite,
-    avatar-aurora-breathe 3.4s ease-in-out infinite;
-}
-
-@keyframes avatar-aurora-spin {
-  from {
-    transform: rotate(0deg);
+  &::before {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 9999px;
+    background: conic-gradient(
+      from 0deg,
+      rgba(125, 249, 255, 0.55),
+      rgba(167, 139, 250, 0.55),
+      rgba(244, 114, 182, 0.55),
+      rgba(253, 224, 71, 0.55),
+      rgba(125, 249, 255, 0.55)
+    );
+    filter: blur(7px);
+    z-index: -1;
+    opacity: 0.85;
+    animation:
+      avatar-aurora-spin 7s linear infinite,
+      avatar-aurora-breathe 3.4s ease-in-out infinite;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes avatar-aurora-breathe {
-  0%,
-  100% {
-    opacity: 0.55;
-    filter: blur(6px);
-  }
-  50% {
-    opacity: 1;
-    filter: blur(10px);
-  }
-}
-
-/* Inner controls: quiet, transparent — never compete with the outer glass.
-   A barely-there stroke gives shape; no second backdrop-filter (one blur layer
-   wins on GPU and visually). */
-.aurora-control {
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.04);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
 /* Conversation area: fully transparent. The outer glass shell IS the surface. */
-.conversation-surface {
+@utility conversation-surface {
   border: none;
   background: transparent;
   box-shadow: none;
 }
 
-/* Locked-state callout: subtle quiet panel (no heavy shadow / no second blur). */
-.spotlight-card {
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
-}
-
 /* Landing hero: keeps the copy readable against the animated background while
    still feeling airy and outside the chat shell. */
-.hero-copy {
+@utility hero-copy {
   position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: -12% 12% auto;
+    height: clamp(160px, 24vw, 280px);
+    border-radius: 9999px;
+    background: radial-gradient(
+      ellipse at center,
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(164, 244, 255, 0.1) 36%,
+      rgba(255, 255, 255, 0) 72%
+    );
+    filter: blur(16px);
+    pointer-events: none;
+    z-index: -1;
+  }
 }
 
-.hero-copy::before {
-  content: "";
-  position: absolute;
-  inset: -12% 12% auto;
-  height: clamp(160px, 24vw, 280px);
-  border-radius: 9999px;
-  background: radial-gradient(
-    ellipse at center,
-    rgba(255, 255, 255, 0.18) 0%,
-    rgba(164, 244, 255, 0.1) 36%,
-    rgba(255, 255, 255, 0) 72%
-  );
-  filter: blur(16px);
-  pointer-events: none;
-  z-index: -1;
-}
-
-.aurora-button {
+@utility aurora-button {
   background: linear-gradient(
     135deg,
     rgba(255, 255, 255, 0.95),
@@ -838,16 +838,16 @@ textarea {
   box-shadow:
     0 14px 32px rgba(8, 47, 73, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.86);
-}
 
-.aurora-button:hover {
-  background: linear-gradient(135deg, #ffffff, #d9fbff 45%, #fff0a8);
+  &:hover {
+    background: linear-gradient(135deg, #ffffff, #d9fbff 45%, #fff0a8);
+  }
 }
 
 /* Example prompts: intentionally readable affordance cards (these SHOULD pop
    slightly so users see them as the primary CTA). Kept lightweight: single
    translucent fill + accent stripe, no second backdrop-filter. */
-.prompt-glass {
+@utility prompt-glass {
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(210, 236, 255, 0.5);
@@ -860,37 +860,14 @@ textarea {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.36),
     0 0 0 1px rgba(125, 211, 252, 0.12);
-}
 
-.prompt-glass::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 4px;
-  background: linear-gradient(180deg, #22d3ee, #a78bfa 52%, #facc15);
-}
-
-.prompt-glass--user::before {
-  inset: 0 0 0 auto;
-}
-
-/* User-message bubble: COMPOSER TWIN. Same gradient, same border, same family
-   — both are "user voice." Subtler glow (no large outer halo) since the
-   bubble is past-input, not active-input. Drop shadow removed per request. */
-.prompt-glass.prompt-glass--user {
-  border: 1px solid rgba(160, 220, 255, 0.42);
-  background:
-    linear-gradient(
-      102deg,
-      rgba(17, 37, 92, 0.82),
-      rgba(26, 54, 128, 0.78) 55%,
-      rgba(98, 34, 121, 0.74)
-    ),
-    rgba(9, 20, 61, 0.64);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.26),
-    0 0 0 1px rgba(83, 185, 255, 0.18),
-    0 0 18px rgba(125, 211, 252, 0.2);
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: linear-gradient(180deg, #22d3ee, #a78bfa 52%, #facc15);
+  }
 }
 
 /* Composer shares the locked-state input's animated prism ring. Both inputs
@@ -899,7 +876,7 @@ textarea {
    existing multi-layer glow (cyan + violet + fuchsia halos) stays as the
    outer halo; the static cyan border + 1px outline are replaced by the
    live gradient sweep applied via ::after with mask-composite. */
-.composer-shell {
+@utility composer-shell {
   position: relative;
   isolation: isolate;
   display: flex;
@@ -931,106 +908,107 @@ textarea {
     0 0 24px rgba(125, 211, 252, 0.42),
     0 0 50px rgba(167, 139, 250, 0.32),
     0 0 90px rgba(217, 70, 239, 0.18);
-}
 
-.composer-shell::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1.5px;
-  background: linear-gradient(
-    120deg,
-    rgba(125, 249, 255, 0.85),
-    rgba(167, 139, 250, 0.85) 32%,
-    rgba(244, 114, 182, 0.85) 58%,
-    rgba(253, 224, 71, 0.7) 82%,
-    rgba(125, 249, 255, 0.85)
-  );
-  background-size: 220% 100%;
-  animation: prism-sweep 6s ease-in-out infinite;
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
+  /* Animated prism INTERIOR fill — same palette + cadence as the locked-state
+     input. Sits between the dark base and the content. Straight alpha (no
+     blend mode) since overlay was too subtle against the dark backdrop. */
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      120deg,
+      rgba(125, 249, 255, 0.6),
+      rgba(167, 139, 250, 0.6) 32%,
+      rgba(244, 114, 182, 0.6) 58%,
+      rgba(253, 224, 71, 0.5) 82%,
+      rgba(125, 249, 255, 0.6)
+    );
+    background-size: 220% 100%;
+    animation: prism-sweep 6s ease-in-out infinite;
+    pointer-events: none;
+  }
 
-/* Animated prism INTERIOR fill — same palette + cadence as the locked-state
-   input. Sits between the dark base and the content. Straight alpha (no
-   blend mode) since overlay was too subtle against the dark backdrop. */
-.composer-shell::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(
-    120deg,
-    rgba(125, 249, 255, 0.6),
-    rgba(167, 139, 250, 0.6) 32%,
-    rgba(244, 114, 182, 0.6) 58%,
-    rgba(253, 224, 71, 0.5) 82%,
-    rgba(125, 249, 255, 0.6)
-  );
-  background-size: 220% 100%;
-  animation: prism-sweep 6s ease-in-out infinite;
-  pointer-events: none;
-}
+  /* Live gradient sweep BORDER via mask-composite. */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1.5px;
+    background: linear-gradient(
+      120deg,
+      rgba(125, 249, 255, 0.85),
+      rgba(167, 139, 250, 0.85) 32%,
+      rgba(244, 114, 182, 0.85) 58%,
+      rgba(253, 224, 71, 0.7) 82%,
+      rgba(125, 249, 255, 0.85)
+    );
+    background-size: 220% 100%;
+    animation: prism-sweep 6s ease-in-out infinite;
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+  }
 
-/* Children sit above the prism-fill ::before so text remains crisp.
-   `:not(.sr-only)` excludes the visually-hidden Label element which relies
-   on `position: absolute` from .sr-only — overriding it back to `relative`
-   made the label a grid item and broke the composer column layout. */
-.composer-shell > :not(.sr-only) {
-  position: relative;
-  z-index: 1;
+  /* Children sit above the prism-fill ::before so text remains crisp.
+     `:not(.sr-only)` excludes the visually-hidden Label element which relies
+     on `position: absolute` from .sr-only — overriding it back to `relative`
+     made the label a grid item and broke the composer column layout. */
+  & > :not(.sr-only) {
+    position: relative;
+    z-index: 1;
+  }
 }
 
 /* Header row — typography-first, no container weight. A 1.5px gradient
    hairline beneath it cleanly separates the header from the conversation
    surface. Apple-style: presence via subtle structure, not chunky bars. */
-.chat-header {
+@utility chat-header {
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   padding-bottom: 1rem;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1.5px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(125, 249, 255, 0.7) 16%,
+      rgba(167, 139, 250, 0.88) 50%,
+      rgba(244, 114, 182, 0.7) 84%,
+      transparent 100%
+    );
+    box-shadow:
+      0 0 8px rgba(167, 139, 250, 0.35),
+      0 0 16px rgba(125, 249, 255, 0.18);
+    pointer-events: none;
+  }
 }
 
-.chat-header::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 1.5px;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(125, 249, 255, 0.7) 16%,
-    rgba(167, 139, 250, 0.88) 50%,
-    rgba(244, 114, 182, 0.7) 84%,
-    transparent 100%
-  );
-  box-shadow:
-    0 0 8px rgba(167, 139, 250, 0.35),
-    0 0 16px rgba(125, 249, 255, 0.18);
-  pointer-events: none;
-}
-
-.composer-field {
+@utility composer-field {
   display: block;
   flex: 1 1 0;
   min-width: 0;
   line-height: 1.35;
 }
 
-.composer-tools {
+@utility composer-tools {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
@@ -1039,7 +1017,7 @@ textarea {
   padding-right: 0.08rem;
 }
 
-.composer-magic {
+@utility composer-magic {
   display: inline-flex;
   height: 2rem;
   width: 2rem;
@@ -1054,15 +1032,15 @@ textarea {
     transform 180ms ease,
     color 180ms ease,
     filter 180ms ease;
+
+  &:hover {
+    transform: scale(1.08);
+    color: rgba(245, 250, 255, 1);
+    filter: drop-shadow(0 0 10px rgba(147, 197, 253, 0.85));
+  }
 }
 
-.composer-magic:hover {
-  transform: scale(1.08);
-  color: rgba(245, 250, 255, 1);
-  filter: drop-shadow(0 0 10px rgba(147, 197, 253, 0.85));
-}
-
-.composer-send {
+@utility composer-send {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1078,59 +1056,46 @@ textarea {
     0 0 0 1px rgba(255, 255, 255, 0.2),
     0 0 22px rgba(217, 70, 239, 0.52),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
+
+  &:disabled {
+    opacity: 0.85;
+  }
 }
 
-.composer-send:disabled {
-  opacity: 0.85;
-}
-
-.chat-scrollbar {
+@utility chat-scrollbar {
   scrollbar-width: none;
-}
 
-.chat-scrollbar::-webkit-scrollbar {
-  width: 0;
-}
-
-.chat-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.chat-scrollbar::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 999px;
-  transition:
-    background 160ms ease,
-    width 160ms ease;
-}
-
-.chat-scrollbar:hover {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-}
-
-.chat-scrollbar:hover::-webkit-scrollbar {
-  width: 5px;
-}
-
-.chat-scrollbar:hover::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.28);
-}
-
-@keyframes dot-pulse {
-  0%,
-  80%,
-  100% {
-    transform: scale(0.7);
-    opacity: 0.45;
+  &::-webkit-scrollbar {
+    width: 0;
   }
-  40% {
-    transform: scale(1);
-    opacity: 1;
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 999px;
+    transition:
+      background 160ms ease,
+      width 160ms ease;
+  }
+
+  &:hover {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar {
+      width: 5px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.28);
+    }
   }
 }
 
-.thinking-dot {
+@utility thinking-dot {
   width: 0.46rem;
   height: 0.46rem;
   border-radius: 9999px;
@@ -1138,31 +1103,18 @@ textarea {
   box-shadow: 0 0 10px rgba(103, 232, 249, 0.6);
   display: inline-block;
   animation: dot-pulse 1s infinite ease-in-out;
-}
 
-.thinking-dot:nth-child(2) {
-  animation-delay: 120ms;
-}
-
-.thinking-dot:nth-child(3) {
-  animation-delay: 220ms;
-}
-
-/* Conditional layout — body[data-chat-locked] is set by a useEffect inside
-   ChatShell. CSS targets it via a plain descendant selector (no :has()
-   dependency, which proved unreliable in some browser/Tailwind v4 combos).
-   Locked → flex column centers vertically as a single group.
-   Unlocked → disclaimer wrapper gets margin-top: auto to pin to viewport
-   bottom; chat shell expands to fill the upper area. */
-@media (min-width: 1024px) {
-  body[data-chat-locked="false"] [data-disclaimer-wrapper] {
-    margin-top: auto;
+  &:nth-child(2) {
+    animation-delay: 120ms;
   }
-  body[data-chat-locked="true"] [data-layout-root] {
-    justify-content: center;
+
+  &:nth-child(3) {
+    animation-delay: 220ms;
   }
 }
 
+/* Accessibility override — kept at TOP LEVEL (outside @layer) so it
+   overrides the animation declarations inside utility-layer classes. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

`frontend/app/globals.css` migrated from hybrid Tailwind v4 (only `@theme` color tokens + `--animate-crowd-*` tokens were v4-native) to **fully v4-native**: every keyframe registered as a `--animate-*` token inside `@theme`, every custom class as `@utility`, base styles in `@layer base`, pseudo-elements + state modifiers nested via `&` parent references.

This was originally PR #22, reverted in PR #23 because the polish branches hadn't merged yet. Now post-polish (PR #24 + #26 + #27 + #28 all on main), the refactor re-applies without conflicts and is extended to cover the polish content (crowd silhouette tokens, conditional-layout selectors, composer prism ring, etc.).

## Grounded in Tailwind v4 docs

Every pattern verified against primary sources before adoption:

| Pattern | Docs reference |
|---|---|
| `@keyframes` lives inside `@theme` alongside `--animate-*` token | [Theme — Animation Registration](https://tailwindcss.com/docs/theme) |
| `@utility foo {}` puts the class in the utilities layer with full variant support | [Adding Custom Styles — @utility directive](https://tailwindcss.com/docs/adding-custom-styles) |
| Nested pseudos (`&::before`, `&::-webkit-scrollbar`) supported inside `@utility` | [Adding Custom Styles — Complex Utilities example](https://tailwindcss.com/docs/adding-custom-styles) |
| `@layer base` for custom base styles alongside Preflight | [Preflight — Extending Preflight](https://tailwindcss.com/docs/preflight) |

## What changed

- **17 `@keyframes` migrated** into `@theme` and paired with `--animate-*` tokens. 3 of those tokens (`--animate-crowd-{bob,fade-a,fade-b}`) already existed from PR #8 and are actively consumed in `crowd-silhouette.tsx`. The other 14 are forward-compat — tree-shaken when unused.
- **28 custom classes** migrated from `.foo {}` to `@utility foo {}`. Each retains its full original CSS (including the multi-layer box-shadow stacks, conic gradients, mask-composite borders, etc.) with pseudo-elements and state modifiers nested via `&`.
- **Base styles wrapped in `@layer base`**: `:root` shell-height vars + 4 responsive `@media` overrides, `*` box-sizing reset, `html`/`body` styles, cursor selectors, `.sr-only` (kept here as a semantic primitive rather than a composable utility), and the `body[data-chat-locked]` conditional-layout media-query block.
- **`@media (prefers-reduced-motion: reduce)` kept at top level** (outside `@layer`) so the accessibility override beats utility-layer animation declarations.

## Dead code removed (re-verified by grep — zero consumers anywhere outside globals.css)

- `@keyframes` × 4: `global-canvas-drift`, `page-aurora-flow`, `ambient-glow-drift`, `ambient-vignette-pulse`
- Classes × 3: `.aurora-control`, `.spotlight-card`, `.prompt-glass--user` (the dual-class + `::before` variant; user messages render via flat amber text in `message-list.tsx`, not a bubble class)

Net: 1175 → 1126 lines.

## Future consolidation candidates (documented, NOT actioned in this PR)

Audit surfaced several FAANG-grade DRY opportunities that are stylistic-not-behavioral and explicitly deferred to preserve the "zero behavior change" guarantee:
- `.locked-input-ring` and `.composer-shell::after` share an identical prism gradient + `prism-sweep` animation — could become a shared `@utility prism-gradient-ring`.
- `.gradient-hairline` and `.chat-header::after` define near-identical horizontal gradient hairlines (slightly different stop percentages).
- Several hardcoded rgba values could become `--color-aurora-cyan-edge` etc. tokens — bigger tokenization PR.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 7 nursery warnings (same baseline as main), 0 errors
- [x] `pnpm build` 5/5 static pages — **critical**: Lightning CSS validates `@utility` + nested `@media` + nested `&::before/::after/[data-state]/:hover` syntax in prod mode
- [x] `pnpm test:e2e` 2/2 pass — session-persistence + scroll restoration unaffected
- [x] **Local visual smoke** — glass shell, composer prism, locked-input ring sweep, AI avatar conic-gradient halo, crowd silhouette cross-fade (most load-bearing — confirms the `--animate-crowd-*` registration still works), heart doodles, prism line, confetti bursts, `prefers-reduced-motion: reduce` toggle

## Non-goals

- JSX files (`.tsx`, `.ts`) — class names unchanged; refactor is CSS-only
- `package.json`, `tsconfig.json`, `biome.json` — unrelated
- `api/index.py` — Python backend
- `.env.example`, `README.md` — already updated in PR #28

Co-authored-by: Cursor <cursoragent@cursor.com>