### PR TITLE
chore(frontend): apply Tailwind canonical class form for calc() values

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -34,8 +34,8 @@ export default async function HomePage() {
           scale with viewport width without ever overlapping or drifting
           to the screen corners. Shown at 2xl+ (>=1536px); below that the
           shell consumes too much horizontal real estate to fit them. */}
-      <LoveIsTheOnlyAnswer className="pointer-events-none absolute top-[18%] z-0 hidden w-[220px] opacity-90 2xl:block 2xl:right-[calc(50%_+_540px)] min-[1800px]:top-[22%] min-[1800px]:w-[260px]" />
-      <LoveIsTheOnlyAnswer className="pointer-events-none absolute top-1/2 z-0 hidden w-[220px] -translate-y-1/2 opacity-90 2xl:block 2xl:left-[calc(50%_+_540px)] min-[1800px]:w-[260px]" />
+      <LoveIsTheOnlyAnswer className="pointer-events-none absolute top-[18%] z-0 hidden w-[220px] opacity-90 2xl:block 2xl:right-[calc(50%+540px)] min-[1800px]:top-[22%] min-[1800px]:w-[260px]" />
+      <LoveIsTheOnlyAnswer className="pointer-events-none absolute top-1/2 z-0 hidden w-[220px] -translate-y-1/2 opacity-90 2xl:block 2xl:left-[calc(50%+540px)] min-[1800px]:w-[260px]" />
 
       {/* Heart doodles — ambient warmth, confined to the TOP HALF of the
           viewport so they never land ON the crowd silhouette (which fills


### PR DESCRIPTION
## Summary

Strips redundant underscores from two `calc()` arbitrary values in `app/page.tsx`, per the canonical form suggested by the official `@tailwindcss/intellisense` extension (rule: `suggestCanonicalClasses`).

```diff
- <LoveIsTheOnlyAnswer className="... 2xl:right-[calc(50%_+_540px)] ..." />
- <LoveIsTheOnlyAnswer className="... 2xl:left-[calc(50%_+_540px)] ..." />
+ <LoveIsTheOnlyAnswer className="... 2xl:right-[calc(50%+540px)] ..." />
+ <LoveIsTheOnlyAnswer className="... 2xl:left-[calc(50%+540px)] ..." />
```

## Why this is the canonical form (and earlier sessions got it wrong)

Tailwind's docs page on arbitrary values says "use underscores for spaces in arbitrary values." That's generic guidance for cases where the CSS value *needs* a space. **For `calc()` operators specifically, Tailwind v4's parser normalizes the output regardless of source form** — both `[calc(50%+540px)]` and `[calc(50%_+_540px)]` compile to the same `calc(50% + 540px)`.

The official `@tailwindcss/intellisense` extension's `suggestCanonicalClasses` rule encodes this precise framework knowledge and explicitly designates the shorter form as canonical. When framework docs prose is ambiguous and framework tooling is specific, **tooling wins** — it carries the precise framework intent that prose docs gloss over.

## Empirical verification

Built locally and grepped emit-CSS before AND after this change:

```
$ grep -o "calc(50[^)]*)" .next/**/*.css | sort -u
calc(50% + 540px)    ← before underscore strip
calc(50% + 540px)    ← after underscore strip
```

Identical. Tailwind v4 emits the spaced form either way.

## Test plan

- [x] `pnpm build` clean
- [x] Emit-CSS diff before/after: identical `calc(50% + 540px)` output
- [ ] Visual: `LoveIsTheOnlyAnswer` decorations at `2xl+` (≥1536px) viewport still anchor correctly to half-width + 540px offset from viewport center — should look identical to current main

## Non-goals

- No CSS changes (PR #29 just landed those)
- No global Tailwind config changes
- No new dependencies or extensions added — the IntelliSense extension is a per-contributor install and not enforced via repo config

Co-authored-by: Cursor <cursoragent@cursor.com>