### PR TITLE
fix(frontend): production-aware metadataBase URL

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,7 +7,13 @@ const SITE_DESCRIPTION =
   "An AI companion for the universe of Coldplay — songs, albums, eras, members, live shows, and everything in between. A non-commercial educational student project.";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("http://localhost:3000"),
+  // Vercel auto-sets VERCEL_URL to the deployment's own hostname for
+  // every prod + preview build. Fall back to localhost in dev. Critical
+  // for social shares: OG image URLs resolve relative to this base, so a
+  // wrong value produces broken Twitter / Slack / LinkedIn cards.
+  metadataBase: new URL(
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000"
+  ),
   title: {
     default: SITE_NAME,
     template: `%s · ${SITE_NAME}`,


### PR DESCRIPTION
## Summary

`metadataBase` was hardcoded to `http://localhost:3000`, which meant production OG image URLs (Open Graph, Twitter Card) resolved relative to localhost. Result: broken social cards on Twitter, Slack, LinkedIn, Discord whenever the public URL is shared.

```diff
- metadataBase: new URL("http://localhost:3000"),
+ metadataBase: new URL(
+   process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000"
+ ),
```

## Why VERCEL_URL

Vercel auto-sets `VERCEL_URL` to the deployment's own hostname for every production AND preview build — part of Vercel's [default System Environment Variables](https://vercel.com/docs/projects/environment-variables/system-environment-variables). No dashboard configuration needed.

| Environment | `metadataBase` value |
|---|---|
| Production | `https://<prod-domain>.vercel.app` |
| Preview | `https://<preview-hash>.vercel.app` |
| Local dev | `http://localhost:3000` |

## Why now

First PR in the Next.js production-readiness sweep ([plan file](../tree/main) covers ~10-12 small PRs). This one is highest-impact-lowest-effort: 1-logical-line change that fixes a real visible-on-social-shares bug before teacher submission.

Per the [Next.js production checklist](https://nextjs.org/docs/app/guides/production-checklist), "Metadata and SEO" section: the Metadata API is the authoritative source for OG / Twitter metadata.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (7 nursery warnings baseline)
- [x] `pnpm build` clean (5/5 static pages)
- [ ] Post-merge: verify OG card resolves correctly by pasting the production URL into a social tool (e.g., https://www.opengraph.xyz/ or Twitter card validator)

## Non-goals

- No UI change
- No env var dashboard config needed (VERCEL_URL is system-default)
- No metadata field changes (title/description/twitter/openGraph all unchanged)

Co-authored-by: Cursor <cursoragent@cursor.com>