### PR TITLE
feat(frontend): @vercel/speed-insights for Core Web Vitals

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,3 +1,4 @@
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 
 import "./globals.css";
@@ -75,6 +76,12 @@ export default function RootLayout({
           Skip to main content
         </a>
         {children}
+        {/* Vercel Speed Insights — Core Web Vitals (LCP, FID, CLS, INP,
+            TTFB, FCP) reported to the Vercel project's Speed Insights
+            tab. No-op when not running on Vercel; zero-config on Vercel
+            Pro. Lives as a sibling of children so it doesn't intercept
+            any layout or styling. */}
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/postcss": "^4.3.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -1273,6 +1276,32 @@ packages:
 
   '@vercel/sandbox@1.9.0':
     resolution: {integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/static-build@2.9.26':
     resolution: {integrity: sha512-xPSE7Du4S0EZrIA7xV40rd/mNR96lJNIMjf15g9cQrNBgYajaZ/DnXbJVQ7mlAfoo36XZFRF+YXTXvNa4qJ7VA==}
@@ -3963,6 +3992,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@vercel/static-build@2.9.26':
     dependencies:


### PR DESCRIPTION
## Summary

Adds [`@vercel/speed-insights`](https://vercel.com/docs/speed-insights) — Vercel's native Core Web Vitals tracker. Real-user CWV metrics (LCP, FID, CLS, INP, TTFB, FCP) report to the Vercel project's Speed Insights tab, no third-party analytics platform required.

## What changed

| File | Change |
|---|---|
| `package.json` | + `@vercel/speed-insights@^2.0.0` dependency |
| `app/layout.tsx` | imports `SpeedInsights` from `@vercel/speed-insights/next`; mounts `<SpeedInsights />` as a sibling of `{children}` inside `<body>` |
| `pnpm-lock.yaml` | regenerated for the new dep |

The `<SpeedInsights />` component is invisible — it emits no DOM, just installs a `web-vitals` listener and POSTs metrics to Vercel's collector. No-op when not running on Vercel.

## Why now (Vercel Pro context)

You upgraded to Vercel Pro, which means **Speed Insights is included** with higher retention and finer granularity than the Hobby tier. This wires the field-data half of the "Core Web Vitals" section in the [Next.js production checklist](https://nextjs.org/docs/app/guides/production-checklist#core-web-vitals); Lighthouse runs (simulated data) remain a complementary user-side task.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (7 nursery warnings baseline; biome lint:fix reordered imports — `@vercel/speed-insights` before `next` per alphabetical rule)
- [x] `pnpm build` clean (5/5 static pages)
- [x] `pnpm test:e2e` 2/2 pass (8.2s)
- [ ] Post-deploy: load the production URL, navigate, then check Vercel project → Speed Insights tab. Metrics typically arrive within 30s of first traffic.

## Wave 1 progress

| | Status |
|---|---|
| PR A: metadataBase | ✓ merged (#31) |
| PR B: bundle-analyzer | ✓ merged (#32) |
| **PR D: speed-insights** | **this PR** |
| PR E: @vercel/analytics | next |
| PR C: not-found.tsx | after E |
| PR F: server-only DAL | last of Wave 1 |

Co-authored-by: Cursor <cursoragent@cursor.com>