### PR TITLE
feat(frontend): @vercel/analytics for page-view tracking

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 
@@ -82,6 +83,11 @@ export default function RootLayout({
             Pro. Lives as a sibling of children so it doesn't intercept
             any layout or styling. */}
         <SpeedInsights />
+        {/* Vercel Web Analytics — anonymous page-view tracking reported
+            to the project's Analytics tab. Same no-op-off-Vercel + no-
+            DOM behavior as SpeedInsights. Companion data: SpeedInsights
+            covers perf, Analytics covers reach. */}
+        <Analytics />
       </body>
     </html>
   );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/postcss": "^4.3.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -1176,6 +1179,35 @@ packages:
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/backends@0.6.0':
     resolution: {integrity: sha512-Fw+9s72dMowyL4HNl4IYCbk0ubvfDDXpgaPENNx49+k248LU9LoLjDOek7gTiAfwiiQK3RViN3327ZLCe0GF/A==}
@@ -3700,6 +3732,11 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/analytics@2.0.1(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@vercel/backends@0.6.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:


### PR DESCRIPTION
## Summary

Companion to PR #33 (`@vercel/speed-insights`). Adds [`@vercel/analytics`](https://vercel.com/docs/analytics) — anonymous page-view + referrer + device tracking that reports to the Vercel project's Analytics tab. Together with Speed Insights, the two SDKs give a complete reach + performance picture.

| SDK | What it tracks | Where it shows up |
|---|---|---|
| `@vercel/speed-insights` (PR #33) | Core Web Vitals (LCP, FID, CLS, INP, TTFB, FCP) | Vercel → Speed Insights tab |
| `@vercel/analytics` (this PR) | Page views, top routes, referrers, devices | Vercel → Analytics tab |

## What changed

| File | Change |
|---|---|
| `package.json` | + `@vercel/analytics@^2.0.1` dependency |
| `app/layout.tsx` | imports `Analytics` from `@vercel/analytics/next`; mounts `<Analytics />` as a sibling of `<SpeedInsights />` inside `<body>` |
| `pnpm-lock.yaml` | regenerated |

Both providers are invisible (no DOM), no-op when not on Vercel.

## Why bundle perf + usage tracking together

Per general production observability guidance: field performance data (CWV) is most actionable when contextualized by usage data (which routes get the most traffic). A slow LCP on a rarely-visited route is a lower priority than a slow LCP on the landing page. Having both flowing to the same Vercel dashboard makes that prioritization native.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (7 nursery warnings baseline)
- [x] `pnpm build` clean (5/5 static pages)
- [x] `pnpm test:e2e` 2/2 pass (8.0s)
- [ ] Post-deploy: visit production URL a few times, check Vercel → Analytics tab. Initial events typically arrive within 30s.

## Wave 1 progress

| | Status |
|---|---|
| PR A: metadataBase | ✓ merged (#31) |
| PR B: bundle-analyzer | ✓ merged (#32) |
| PR D: speed-insights | ✓ merged (#33) |
| **PR E: analytics** | **this PR** |
| PR C: not-found.tsx | next (visual change — will need local verify) |
| PR F: server-only DAL | last of Wave 1 |

Co-authored-by: Cursor <cursoragent@cursor.com>