### PR TITLE
feat(frontend): custom not-found.tsx with brand voice

### DIFF
--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+/**
+ * Custom 404 page — rendered by Next.js for any unmatched route inside
+ * the app/ tree. Sits inside RootLayout, so it inherits the aurora
+ * gradient background, the skip-link, and the SpeedInsights / Analytics
+ * trackers. Same chat-shell-glass + prism-gradient design language as
+ * the route-level error boundary so the brand voice stays consistent on
+ * edge cases.
+ *
+ * Server Component (no "use client") — there's no interactivity beyond
+ * a Link, which Next.js client-navigates without a directive.
+ */
+export default function NotFound() {
+  return (
+    <main className="relative isolate flex min-h-svh items-center justify-center px-4 py-8">
+      <section
+        aria-labelledby="not-found-heading"
+        className="chat-shell-glass mx-auto flex w-full max-w-[520px] flex-col items-center gap-5 rounded-3xl p-10 text-center text-white"
+      >
+        <span className="prism-line" aria-hidden />
+        <h1
+          id="not-found-heading"
+          className="m-0 bg-linear-to-r from-cyan-300 via-fuchsia-400 to-violet-400 bg-clip-text font-bold text-7xl text-transparent tracking-tight sm:text-8xl"
+        >
+          404
+        </h1>
+        <p className="m-0 max-w-[32ch] text-base text-white/85 leading-relaxed sm:text-lg">
+          Lost in the universe of <strong>Coldplay</strong>.
+        </p>
+        <Link
+          href="/"
+          className="aurora-button rounded-full px-6 py-2 font-semibold text-base no-underline"
+        >
+          Take me home
+        </Link>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Wrong-URL visitors now get a Coldplay-AI-Companion-branded 404 instead of the bare Next.js default. Hero-sized "404" in the prism gradient (same palette as the route-error boundary), a single tagline anchored to the hero subtitle's "universe of Coldplay" framing, and an `aurora-button` link home.

```
   ─── prism gradient line ───

           4 0 4              ← gradient hero, 72px → 96px@sm

   Lost in the universe of Coldplay.

           [ Take me home ]
```

## Why this composition

| Decision | Reasoning |
|---|---|
| Hero-sized 404 in gradient | The number is the universal "this is a 404" signal — making it the visual anchor (not a tiny eyebrow) lets users recognize the state instantly |
| Single tagline (~7 words) | Less is more on edge-case pages. References the hero subtitle's "universe of Coldplay" so the page reads as part of the brand world, not as boilerplate. `Coldplay` bolded per the project's "proper nouns in **bold**" rule |
| Reuses existing `@utility` classes | `chat-shell-glass` panel, `prism-line` decoration, `aurora-button` CTA — same vocabulary as the rest of the app. No new CSS needed |
| Server Component | No state, no event handlers — only a `<Link>` which Next.js client-navigates without `"use client"` |
| `aria-labelledby` pointing at H1 | Canonical accessibility pattern over a generic `aria-label`. The 404 H1 carries the semantic landmark |

## What changed

| File | Change |
|---|---|
| `app/not-found.tsx` | NEW — 40 lines |

That's it. Zero touches to anything else — the page composes entirely from existing primitives.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (7 nursery warnings baseline)
- [x] `pnpm build` clean (5/5 static pages — `/_not-found` is now custom-rendered, was previously the Next.js default)
- [x] `pnpm test:e2e` 2/2 pass
- [x] **Local visual smoke** — navigated to `/garbage-url`, hard-reloaded, confirmed: hero 404 in prism gradient, single tagline with Coldplay bolded, aurora-button CTA, panel sits cleanly on the aurora gradient background

## Wave 1 progress

| | Status |
|---|---|
| PR A: metadataBase | ✓ merged (#31) |
| PR B: bundle-analyzer | ✓ merged (#32) |
| PR D: speed-insights | ✓ merged (#33) |
| PR E: analytics | ✓ merged (#34) |
| **PR C: not-found** | **this PR** |
| PR F: server-only DAL | last of Wave 1 |

Co-authored-by: Cursor <cursoragent@cursor.com>