### PR TITLE
fix(frontend): kill locked-card load reflow + first-mount animation

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -394,17 +394,21 @@
     border: 0;
   }
 
-  /* Conditional layout — body[data-chat-locked] is set by a useEffect inside
-     ChatShell. CSS targets it via a plain descendant selector (no :has()
-     dependency, which proved unreliable in some browser/Tailwind v4 combos).
+  /* Conditional layout — `data-chat-locked` is set ON THE SAME ELEMENT
+     (`[data-layout-root]`) at SSR time from `app/page.tsx` so the locked
+     layout is correct on FIRST PAINT (no hydration race where the shell
+     briefly renders at the top then reflows to centered). ChatShell
+     syncs it on client state changes via the same attribute. Targeting
+     the element directly (not via `body`) avoids the prior boot-time
+     window when the body attribute hadn't yet been written.
      Locked → flex column centers vertically as a single group.
-     Unlocked → disclaimer wrapper gets margin-top: auto to pin to viewport
-     bottom; chat shell expands to fill the upper area. */
+     Unlocked → disclaimer wrapper gets margin-top: auto to pin to
+     viewport bottom; chat shell expands to fill the upper area. */
   @media (min-width: 1024px) {
-    body[data-chat-locked="false"] [data-disclaimer-wrapper] {
+    [data-layout-root][data-chat-locked="false"] [data-disclaimer-wrapper] {
       margin-top: auto;
     }
-    body[data-chat-locked="true"] [data-layout-root] {
+    [data-layout-root][data-chat-locked="true"] {
       justify-content: center;
     }
   }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -61,12 +61,20 @@ export default async function HomePage() {
 
       <AuroraBackground />
 
-      {/* Layout root — CSS in globals.css reads `body[data-chat-locked]`
-          (set by useEffect in ChatShell) and switches flex behavior:
-          locked → justify-content: center (whole content block centers
-          vertically); unlocked → disclaimer wrapper gets mt-auto so the
-          chat shell expands at top and the footer pins to bottom. */}
-      <div data-layout-root className="mx-auto flex w-full max-w-[1320px] flex-col gap-4 lg:h-full">
+      {/* Layout root — CSS in globals.css reads `[data-layout-root]
+          [data-chat-locked]` and switches flex behavior: locked →
+          justify-content: center (whole content block centers vertically);
+          unlocked → disclaimer wrapper gets mt-auto so the chat shell
+          expands at top and the footer pins to bottom. The attribute is
+          set HERE on the server so first paint matches final layout — no
+          hydration race where the shell briefly renders at the top then
+          reflows to center. ChatShell still syncs it on client state
+          changes (verify / disconnect). */}
+      <div
+        data-layout-root
+        data-chat-locked={initialIsApiKeyVerified ? "false" : "true"}
+        className="mx-auto flex w-full max-w-[1320px] flex-col gap-4 lg:h-full"
+      >
         <Hero />
         <ChatShell initialIsApiKeyVerified={initialIsApiKeyVerified} />
         <div data-disclaimer-wrapper>

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -13,6 +13,12 @@ interface ChatPanelProps {
   isChatLocked: boolean;
   isRestoringChatState: boolean;
   isSwappingPanel: boolean;
+  /**
+   * True on the very first render only — gates `panel-enter` so the
+   * panel is static on initial paint and only animates on the verified
+   * ↔ locked transition. Flipped by a post-mount `useState` in ChatShell.
+   */
+  isInitialPaint: boolean;
   errorMessage: string | null;
   conversationContainerRef: RefObject<HTMLElement | null>;
   endOfMessagesRef: RefObject<HTMLDivElement | null>;
@@ -41,6 +47,7 @@ export function ChatPanel({
   isChatLocked,
   isRestoringChatState,
   isSwappingPanel,
+  isInitialPaint,
   errorMessage,
   conversationContainerRef,
   endOfMessagesRef,
@@ -58,7 +65,7 @@ export function ChatPanel({
     <div
       className={cn(
         "flex min-h-0 flex-1 flex-col gap-3 sm:gap-4",
-        isSwappingPanel ? "panel-exit" : "panel-enter"
+        isSwappingPanel ? "panel-exit" : isInitialPaint ? null : "panel-enter"
       )}
     >
       {isRestoringChatState ? (

--- a/frontend/components/chat/chat-shell.tsx
+++ b/frontend/components/chat/chat-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { ConnectionStatusCard } from "@/components/chat/connection-status-card";
@@ -59,15 +59,28 @@ export function ChatShell({ initialIsApiKeyVerified }: ChatShellProps) {
 
   const isChatLocked = !key.isApiKeyVerified;
 
-  // Sync chat-locked state to `document.body` so CSS in globals.css can flip
-  // the page layout (centered when locked, top-anchored when unlocked) via a
-  // plain attribute selector — more reliable across browsers than `:has()`.
+  // Sync chat-locked state to `[data-layout-root]` so CSS in globals.css
+  // flips page layout (centered when locked, top-anchored when unlocked).
+  // The attribute is ALSO set on the server in `app/page.tsx`, so first
+  // paint already has the correct layout — this effect only handles
+  // subsequent state changes (verify / disconnect).
   useEffect(() => {
-    document.body.dataset.chatLocked = isChatLocked ? "true" : "false";
-    return () => {
-      delete document.body.dataset.chatLocked;
-    };
+    const root = document.querySelector<HTMLElement>("[data-layout-root]");
+    if (root) {
+      root.dataset.chatLocked = isChatLocked ? "true" : "false";
+    }
   }, [isChatLocked]);
+
+  // First-paint animation gate. Without it, `panel-enter` fires on the
+  // very first mount because `isSwappingPanel === false` is true both
+  // BEFORE any swap (initial mount) and AFTER one finishes. We only
+  // want the entry animation on the locked ↔ verified TRANSITION, so
+  // hold it off until after hydration.
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+  const isInitialPaint = !hasMounted;
 
   // Ambient confetti — fireworks + side cannons cycle while the chat is
   // unlocked. Paused while locked, hidden tab, or `prefers-reduced-motion`.
@@ -181,6 +194,7 @@ export function ChatShell({ initialIsApiKeyVerified }: ChatShellProps) {
                     keyFeedback={key.keyFeedback}
                     keyFeedbackTone={key.keyFeedbackTone}
                     isSwappingPanel={key.isSwappingPanel}
+                    isInitialPaint={isInitialPaint}
                   />
                 </div>
               ) : (
@@ -190,6 +204,7 @@ export function ChatShell({ initialIsApiKeyVerified }: ChatShellProps) {
                   isChatLocked={isChatLocked}
                   isRestoringChatState={persistence.isRestoringChatState}
                   isSwappingPanel={key.isSwappingPanel}
+                  isInitialPaint={isInitialPaint}
                   errorMessage={streaming.errorMessage}
                   conversationContainerRef={persistence.conversationContainerRef}
                   endOfMessagesRef={persistence.endOfMessagesRef}

--- a/frontend/components/chat/locked-key-card.tsx
+++ b/frontend/components/chat/locked-key-card.tsx
@@ -25,6 +25,12 @@ interface LockedKeyCardProps {
   keyFeedback: string | null;
   keyFeedbackTone: KeyFeedbackTone | null;
   isSwappingPanel: boolean;
+  /**
+   * True on the very first render only — gates `panel-enter` so the card
+   * is static on initial paint and only animates on the locked → verified
+   * transition (or back). Flipped by a post-mount `useState` in ChatShell.
+   */
+  isInitialPaint: boolean;
 }
 
 /**
@@ -43,6 +49,7 @@ export function LockedKeyCard({
   keyFeedback,
   keyFeedbackTone,
   isSwappingPanel,
+  isInitialPaint,
 }: LockedKeyCardProps) {
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     // Fire the audio kick-off synchronously inside the user-gesture frame
@@ -58,7 +65,7 @@ export function LockedKeyCard({
       aria-label="OpenAI key verification"
       className={cn(
         "flex flex-col items-center gap-3 px-2 py-2 text-center sm:gap-4 sm:py-4",
-        isSwappingPanel ? "panel-exit" : "panel-enter"
+        isSwappingPanel ? "panel-exit" : isInitialPaint ? null : "panel-enter"
       )}
     >
       <h2 className="m-0 bg-linear-to-r from-cyan-300 via-fuchsia-400 to-violet-400 bg-clip-text font-bold text-transparent text-xl leading-tight sm:text-2xl">


### PR DESCRIPTION
## Summary

Two compounding bugs caused the chat shell to briefly render at the top of the viewport then settle/slide to center on first paint (≥1024px). Both fixed atomically.

**A — Hydration layout race.** `data-chat-locked` was written client-side in a `useEffect`, so SSR HTML carried no attribute. CSS at `globals.css:403-410` couldn't match `body[data-chat-locked="true"]` → `[data-layout-root]` defaulted to `justify-content: flex-start` on first paint. Hydration flipped the attribute and the stack reflowed to center.
**Fix:** set `data-chat-locked` on `[data-layout-root]` itself from the server (`app/page.tsx`). CSS targets the element directly. Client `useEffect` remains for verify/disconnect state sync — now operating on the same element, idempotent on mount.

**B — `panel-enter` fired on initial mount.** `isSwappingPanel === false` is true both BEFORE any swap (initial paint) AND after one completes, so the 220ms `panel-in` keyframe (`translateY 8px → 0`, `opacity 0 → 1`, `blur 3px → 0`) ran on every first render.
**Fix:** `hasMounted` state in `ChatShell` flipped in a post-mount effect; both `LockedKeyCard` and `ChatPanel` apply `panel-enter` only when `!isInitialPaint`. Verify ↔ disconnect transitions still animate normally.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings introduced
- [x] `pnpm build` — production build succeeds
- [x] Local visual verify in browser: hard reload at `localhost:3000` in incognito with caches nuked — chat shell renders centered, static, no movement.
- [x] Verify flow still animates the locked → unlocked transition (`panel-exit` then `panel-enter` on the chat panel mount).
- [x] Disconnect flow still animates the unlocked → locked transition.
- [ ] Reviewer visual check on Vercel preview.

Co-authored-by: Cursor <cursoragent@cursor.com>