### PR TITLE
fix(frontend): suppressHydrationWarning on <body>

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -66,7 +66,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      {/* Browser extensions (ColorZilla `cz-shortcut-listen`, 1Password,
+          Grammarly, dark-reader, etc.) inject `<body>` attributes between
+          SSR and hydration. suppressHydrationWarning silences ONLY the
+          attribute mismatch on this element — real React-tree drift in
+          the subtree still warns. */}
+      <body suppressHydrationWarning>
         {/* Skip-link: keyboard users tab to it first; visually hidden
             until focused. Targets the `id="main-content"` landmark on
             HomePage so the chat is reachable in one keystroke. */}


### PR DESCRIPTION
## Summary

- Adds `suppressHydrationWarning` to `<body>` in `app/layout.tsx`. Documented React/Next.js pattern for the exact case where browser extensions mutate the DOM between SSR and hydration.
- Targets `cz-shortcut-listen` from ColorZilla and equivalents from 1Password, Grammarly, dark-reader, etc. Removes the red dev-overlay error on first refresh that any user with such an extension hits.
- Discovered during the PR #39 (Bug #2) visual smoke. Pre-existing on main, not a regression from any recent PR.

## Why this is safe

`suppressHydrationWarning` silences **only** the attribute mismatch on the element it's applied to. It does **not** suppress hydration warnings for:

- Different component types in the subtree
- Mismatched children inside `<body>`
- Real React-tree drift anywhere below `<body>`

It is the React-team-blessed escape hatch for this exact class of extension-induced attribute mismatch. Production builds were already silently recovering this case; this PR removes the dev-overlay noise that users with DOM-mutating extensions kept hitting.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — warnings unchanged (pre-existing nursery class-sort, not introduced)
- [x] `pnpm build` — clean: 5/5 static pages generated
- [x] Local production-mode visual smoke — refresh with ColorZilla installed → no hydration warning (was reproducible on `main` before this PR)

Tests not re-run — no runtime behavior change. Pre-existing unit-test drift (`tests/chat-route.test.ts:94,140`) from earlier sweep work is unaffected by this PR.

## Test plan

- [ ] Deploy preview on Vercel
- [ ] Hit preview with a DOM-mutating extension installed (ColorZilla / 1Password / Grammarly / dark-reader) — confirm no console hydration warning on first paint
- [ ] Confirm no regression on the locked → verified → chat → disconnect flow

Co-authored-by: Cursor <cursoragent@cursor.com>