### PR TITLE
refactor(frontend): move verifyOpenAiKeyAction to /api/verify-key

### DIFF
--- a/frontend/app/actions.ts
+++ b/frontend/app/actions.ts
@@ -1,33 +1,19 @@
 "use server";
 
-import { clearVerifiedKey, hasVerifiedKey, verifyAndStoreKey } from "@/lib/data/auth";
-import { verifyKeyInputSchema } from "@/lib/schemas";
+import { clearVerifiedKey, hasVerifiedKey } from "@/lib/data/auth";
 
 /**
  * Server Actions — the "use server" boundary callable from Client
- * Components. Each action validates client input via zod, delegates to
- * the `lib/data/auth` Data Access Layer, and returns a UI-facing DTO.
+ * Components. Each action delegates to the `lib/data/auth` Data Access
+ * Layer.
  *
- * VerifyKeyResult is intentionally defined here (not re-exported from
- * the DAL) — "use server" files require strict export shapes; defining
- * the type locally keeps the file boundary clean.
+ * The verify path used to live here as `verifyOpenAiKeyAction(rawKey)`.
+ * It was migrated to a route handler at `POST /api/verify-key` because
+ * Next.js logs Server Action arguments to the dev-mode (`pnpm dev`)
+ * terminal — a developer-class leak for the raw sk-... key. The `has`
+ * and `clear` actions stay here: they take no arguments, so no payload
+ * is ever logged.
  */
-
-export interface VerifyKeyResult {
-  ok: boolean;
-  message: string;
-}
-
-export async function verifyOpenAiKeyAction(rawKey: string): Promise<VerifyKeyResult> {
-  const parsed = verifyKeyInputSchema.safeParse(rawKey);
-  if (!parsed.success) {
-    return {
-      ok: false,
-      message: "Invalid key format. OpenAI keys usually start with 'sk-' and are longer.",
-    };
-  }
-  return verifyAndStoreKey(parsed.data);
-}
 
 /**
  * Server-side "is the user verified" check. Used by client components

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { isSameOrigin } from "@/lib/csrf";
 import { getVerifiedKey } from "@/lib/data/auth";
 import { serverEnv } from "@/lib/env";
 import { checkRateLimit, getClientKey } from "@/lib/rate-limit";
@@ -40,28 +41,6 @@ const COLDPLAY_SYSTEM_PROMPT = [
   "- Italicize emotional/descriptive phrases sparingly with *single asterisks*.\n",
   "- Do not use headings (#) inline — keep responses flowing prose + lists.",
 ].join("");
-
-/**
- * Same-origin guard (CSRF defense-in-depth). Server Actions get free CSRF
- * protection from Next.js; route handlers do not. Reject any POST whose
- * Origin header doesn't match the request URL host. Cookies might travel
- * cross-site even with sameSite=strict on browsers that don't honor it
- * correctly; this is belt + suspenders.
- *
- * Missing Origin (server-to-server probe / curl without --header Origin)
- * also fails closed — legitimate browsers always include Origin on POST.
- */
-function isSameOrigin(request: Request): boolean {
-  const origin = request.headers.get("origin");
-  if (!origin) {
-    return false;
-  }
-  try {
-    return new URL(origin).host === new URL(request.url).host;
-  } catch {
-    return false;
-  }
-}
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID();

--- a/frontend/app/api/verify-key/route.ts
+++ b/frontend/app/api/verify-key/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+
+import { isSameOrigin } from "@/lib/csrf";
+import { verifyAndStoreKey } from "@/lib/data/auth";
+import { checkRateLimit, getClientKey } from "@/lib/rate-limit";
+import { verifyKeyRequestSchema } from "@/lib/schemas";
+
+/**
+ * POST /api/verify-key
+ *
+ * Why this is a route handler, not a Server Action: Next.js logs Server
+ * Action arguments to the dev-mode (`pnpm dev`) terminal. With a
+ * `verifyOpenAiKeyAction(rawKey)` signature, the raw sk-... key landed
+ * in dev stdout every time a developer verified locally. Route handlers
+ * do NOT log their request bodies, so this endpoint closes that
+ * developer-class secret leak. Production was already unaffected.
+ *
+ * IMPORTANT: do NOT add any `console.log` of `body`, `parsed.data`, or
+ * any string that could contain the key. A single rogue log would undo
+ * the entire purpose of this migration.
+ */
+
+export const runtime = "nodejs";
+
+// 1KB body cap. Verify body is `{"key":"sk-..."}`, max ~280 bytes for a
+// 256-char key + JSON wrapper. Anything materially larger is junk or
+// an attempt to exhaust the JSON parser before zod validation.
+const MAX_REQUEST_BODY_BYTES = 1 * 1024;
+
+export async function POST(request: Request): Promise<Response> {
+  const requestId = crypto.randomUUID();
+
+  // Cheapest guard first — drops obvious cross-site abuse before any
+  // body parsing or upstream OpenAI call.
+  if (!isSameOrigin(request)) {
+    return NextResponse.json(
+      { detail: "Cross-origin requests are not permitted." },
+      { status: 403, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  // Per-IP sliding-window rate limit. Shared bucket with /api/chat
+  // so an abusive verify burst consumes the same client's chat
+  // budget — a feature for abuse prevention, not a bug.
+  const rateLimit = await checkRateLimit(getClientKey(request));
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      {
+        detail: `Too many requests. Please wait ${rateLimit.retryAfterSec}s and try again.`,
+      },
+      {
+        status: 429,
+        headers: {
+          "x-request-id": requestId,
+          "Retry-After": String(rateLimit.retryAfterSec),
+          "X-RateLimit-Remaining": String(rateLimit.remaining),
+          "X-RateLimit-Reset": String(rateLimit.resetAt),
+        },
+      }
+    );
+  }
+
+  // Content-Length pre-check — cheap reject before we buffer the body.
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_REQUEST_BODY_BYTES) {
+      return NextResponse.json(
+        { detail: "Request body too large." },
+        { status: 413, headers: { "x-request-id": requestId } }
+      );
+    }
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { detail: "Invalid JSON body." },
+      { status: 400, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  const parsed = verifyKeyRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { detail: parsed.error.issues[0]?.message ?? "Invalid request." },
+      { status: 400, headers: { "x-request-id": requestId } }
+    );
+  }
+
+  // Delegate to the DAL — it does OpenAI ping + AES-256-GCM seal +
+  // httpOnly/sameSite=strict cookie set + UI-facing DTO. `parsed.data.key`
+  // is passed once and immediately goes out of scope; the key never
+  // touches a log statement on this call path.
+  const result = await verifyAndStoreKey(parsed.data.key);
+
+  // 200 even for `ok: false` credential rejection — the REQUEST was
+  // well-formed; OpenAI declined the credential. Mirrors the Server
+  // Action contract so the client's error-handling code is unchanged.
+  return NextResponse.json(result, {
+    status: 200,
+    headers: { "x-request-id": requestId },
+  });
+}

--- a/frontend/lib/csrf.ts
+++ b/frontend/lib/csrf.ts
@@ -1,0 +1,31 @@
+/**
+ * CSRF defense-in-depth helpers for route handlers.
+ *
+ * Server Actions get free CSRF protection from Next.js; route handlers do
+ * not. Every state-changing route handler (`/api/chat`, `/api/verify-key`,
+ * ...) calls `isSameOrigin(request)` before any work to reject obvious
+ * cross-site abuse cheaply.
+ *
+ * The check is intentionally strict:
+ *   • Missing Origin header → false (curl probes / server-to-server abuse
+ *     fails closed). Legitimate browsers always include Origin on POST.
+ *   • Malformed Origin URL → false.
+ *   • Origin host ≠ request URL host → false.
+ *
+ * Defense in depth — `sameSite: "strict"` on the session cookie already
+ * blocks cross-site cookie carry on conformant browsers. This guard
+ * closes the gap on non-conformant ones and on direct curl-style abuse
+ * that doesn't go through a browser at all.
+ */
+
+export function isSameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) {
+    return false;
+  }
+  try {
+    return new URL(origin).host === new URL(request.url).host;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/lib/hooks/use-key-lifecycle.ts
+++ b/frontend/lib/hooks/use-key-lifecycle.ts
@@ -1,7 +1,8 @@
 import { type FormEvent, useCallback, useState, useTransition } from "react";
 
-import { clearVerifiedKeyAction, verifyOpenAiKeyAction } from "@/app/actions";
+import { clearVerifiedKeyAction } from "@/app/actions";
 import type { ChatMessage } from "@/lib/chat-types";
+import type { VerifyKeyResult } from "@/lib/data/auth";
 
 export type KeyFeedbackTone = "success" | "error" | "info";
 
@@ -74,7 +75,24 @@ export function useKeyLifecycle({
       setKeyFeedback(null);
       setKeyFeedbackTone(null);
       startKeyVerification(async () => {
-        const result = await verifyOpenAiKeyAction(apiKeyInput);
+        // POST /api/verify-key (route handler, not Server Action). Route
+        // handlers don't log request bodies, so the raw sk-... key stays
+        // out of dev-mode stdout. Server-action arg-logging was the leak
+        // this migration closes.
+        let result: VerifyKeyResult;
+        try {
+          const response = await fetch("/api/verify-key", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ key: apiKeyInput }),
+          });
+          result = (await response.json()) as VerifyKeyResult;
+        } catch {
+          result = {
+            ok: false,
+            message: "Network unreachable. Check your connection and try again.",
+          };
+        }
         setKeyFeedback(result.message);
         setKeyFeedbackTone(result.ok ? "success" : "error");
         if (result.ok) {

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -60,6 +60,17 @@ export function isPlausibleOpenAiKey(value: string): boolean {
   return verifyKeyInputSchema.safeParse(value).success;
 }
 
+/**
+ * POST /api/verify-key body envelope. The route handler unwraps `key`
+ * and feeds the inner string to the existing `verifyKeyInputSchema`
+ * via composition — one source of truth for the sk-... key shape.
+ */
+export const verifyKeyRequestSchema = z.object({
+  key: verifyKeyInputSchema,
+});
+
+export type VerifyKeyRequest = z.infer<typeof verifyKeyRequestSchema>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Boundary — sessionStorage persisted chat UI state
 // ─────────────────────────────────────────────────────────────────────────────

--- a/frontend/tests/actions.test.ts
+++ b/frontend/tests/actions.test.ts
@@ -8,8 +8,8 @@ vi.mock("next/headers", () => ({
   cookies: cookiesMock,
 }));
 
-import { clearVerifiedKeyAction, hasVerifiedKeyAction, verifyOpenAiKeyAction } from "@/app/actions";
-import { seal, unseal } from "@/lib/session-crypto";
+import { clearVerifiedKeyAction, hasVerifiedKeyAction } from "@/app/actions";
+import { seal } from "@/lib/session-crypto";
 
 function createCookieStore(initialValue?: string) {
   return {
@@ -29,67 +29,6 @@ describe("app/actions", () => {
     vi.restoreAllMocks();
     cookiesMock.mockReset();
     vi.stubGlobal("fetch", vi.fn());
-  });
-
-  it("rejects obviously invalid key formats without network call", async () => {
-    const result = await verifyOpenAiKeyAction("not-a-key");
-
-    expect(result.ok).toBe(false);
-    expect(result.message).toContain("Invalid key format");
-    expect(fetch).not.toHaveBeenCalled();
-  });
-
-  it("stores key sealed (AES-256-GCM) in a secure httpOnly strict cookie on successful verification", async () => {
-    const cookieStore = createCookieStore();
-    cookiesMock.mockResolvedValue(cookieStore);
-    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
-
-    const rawKey = "sk-valid-key-12345678901234567890";
-    const result = await verifyOpenAiKeyAction(rawKey);
-
-    expect(result.ok).toBe(true);
-    expect(cookieStore.set).toHaveBeenCalledWith(
-      "openai_api_key",
-      expect.any(String),
-      expect.objectContaining({
-        httpOnly: true,
-        sameSite: "strict",
-        path: "/",
-      })
-    );
-    // Stored value must be the sealed form, never the raw key. Verifies
-    // the H2 invariant: raw key never lands in the cookie jar.
-    const storedValue = cookieStore.set.mock.calls[0]?.[1] as string;
-    expect(storedValue).not.toBe(rawKey);
-    expect(storedValue.split(".").length).toBe(3);
-    expect(unseal(storedValue)).toBe(rawKey);
-  });
-
-  it("returns explicit auth failure for revoked or invalid keys", async () => {
-    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 401 }));
-
-    const result = await verifyOpenAiKeyAction("sk-invalid-key-12345678901234567890");
-
-    expect(result.ok).toBe(false);
-    expect(result.message).toContain("invalid, revoked, or expired");
-  });
-
-  it("treats 429 as recognized key but warns about limits", async () => {
-    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 429 }));
-
-    const result = await verifyOpenAiKeyAction("sk-rate-limited-key-123456789012345");
-
-    expect(result.ok).toBe(true);
-    expect(result.message).toContain("rate-limited");
-  });
-
-  it("returns network failure guidance when OpenAI cannot be reached", async () => {
-    vi.mocked(fetch).mockRejectedValue(new Error("socket hang up"));
-
-    const result = await verifyOpenAiKeyAction("sk-network-fail-key-1234567890123456");
-
-    expect(result.ok).toBe(false);
-    expect(result.message).toContain("Could not reach OpenAI");
   });
 
   it("detects whether a plausible verified key cookie exists (sealed form)", async () => {

--- a/frontend/tests/verify-key-route.test.ts
+++ b/frontend/tests/verify-key-route.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cookiesMock, checkRateLimitMock } = vi.hoisted(() => ({
+  cookiesMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: checkRateLimitMock,
+  getClientKey: () => "test-client",
+}));
+
+import { POST } from "@/app/api/verify-key/route";
+
+const VALID_KEY = "sk-valid-test-1234567890123456789012";
+
+function createCookieStore() {
+  return {
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function makeJsonRequest(body: unknown, origin = "http://localhost"): Request {
+  return new Request("http://localhost/api/verify-key", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: origin,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("app/api/verify-key/route", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cookiesMock.mockReset();
+    cookiesMock.mockResolvedValue(createCookieStore());
+    checkRateLimitMock.mockReset();
+    checkRateLimitMock.mockResolvedValue({
+      allowed: true,
+      remaining: 19,
+      resetAt: Date.now() + 60_000,
+      retryAfterSec: 0,
+    });
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("req-fixed-123");
+  });
+
+  it("rejects requests with no Origin header (server-to-server probes)", async () => {
+    const originlessRequest = new Request("http://localhost/api/verify-key", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: VALID_KEY }),
+    });
+
+    const response = await POST(originlessRequest);
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(403);
+    expect(payload.detail).toContain("Cross-origin");
+    expect(response.headers.get("x-request-id")).toBe("req-fixed-123");
+  });
+
+  it("rejects cross-origin POSTs with 403 (CSRF defense-in-depth)", async () => {
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }, "https://evil.example.com"));
+    expect(response.status).toBe(403);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate limit exceeded", async () => {
+    checkRateLimitMock.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      retryAfterSec: 30,
+    });
+
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(429);
+    expect(payload.detail).toContain("Too many requests");
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  // NOTE: the 413 Content-Length guard at MAX_REQUEST_BODY_BYTES is not
+  // unit-tested here because `Content-Length` is a "forbidden request
+  // header" per the Fetch spec — undici silently strips manual sets on
+  // the Request constructor, and small string bodies don't always
+  // auto-populate Content-Length in the Node test env. In production
+  // the runtime (browser/Vercel) sets Content-Length from the actual
+  // payload, so the guard fires correctly. Visual prod-mode smoke +
+  // upstream pen-tests cover this path. Same pattern as chat-route.
+
+  it("returns 400 on invalid JSON body", async () => {
+    const invalidJsonRequest = new Request("http://localhost/api/verify-key", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "http://localhost",
+      },
+      body: "{not-json",
+    });
+
+    const response = await POST(invalidJsonRequest);
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.detail).toContain("Invalid JSON");
+  });
+
+  it("returns 400 when the `key` field is missing", async () => {
+    const response = await POST(makeJsonRequest({ notKey: "something" }));
+
+    expect(response.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the key is shorter than 24 characters", async () => {
+    const response = await POST(makeJsonRequest({ key: "sk-short" }));
+
+    expect(response.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the key does not start with 'sk-'", async () => {
+    const response = await POST(makeJsonRequest({ key: "not-an-openai-key-1234567890" }));
+    const payload = (await response.json()) as { detail: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.detail).toContain("sk-");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("stores key sealed in a secure cookie on OpenAI 200 (happy path)", async () => {
+    const cookieStore = createCookieStore();
+    cookiesMock.mockResolvedValue(cookieStore);
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }));
+    const payload = (await response.json()) as { ok: boolean; message: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.message).toContain("verified");
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      "openai_api_key",
+      expect.any(String),
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: "strict",
+        path: "/",
+      })
+    );
+    // Stored value must be the sealed form, never the raw key.
+    const storedValue = cookieStore.set.mock.calls[0]?.[1] as string;
+    expect(storedValue).not.toBe(VALID_KEY);
+    expect(storedValue.split(".").length).toBe(3);
+  });
+
+  it("returns ok=false when OpenAI rejects the key (401)", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 401 }));
+
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }));
+    const payload = (await response.json()) as { ok: boolean; message: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(false);
+    expect(payload.message).toContain("invalid, revoked, or expired");
+  });
+
+  it("returns ok=true with warning when OpenAI rate-limits (429)", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 429 }));
+
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }));
+    const payload = (await response.json()) as { ok: boolean; message: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.message).toContain("rate-limited");
+  });
+
+  it("returns ok=false with network guidance when OpenAI is unreachable", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("socket hang up"));
+
+    const response = await POST(makeJsonRequest({ key: VALID_KEY }));
+    const payload = (await response.json()) as { ok: boolean; message: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(false);
+    expect(payload.message).toContain("Could not reach OpenAI");
+  });
+});

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -5,6 +5,9 @@
     "app/api/chat/route.ts": {
       "maxDuration": 60
     },
+    "app/api/verify-key/route.ts": {
+      "maxDuration": 10
+    },
     "app/api/csp-report/route.ts": {
       "maxDuration": 5
     },


### PR DESCRIPTION
## Summary

- Migrates the OpenAI key verification path from a Server Action (`verifyOpenAiKeyAction`) to a `POST /api/verify-key` route handler. **Reason:** Next.js logs Server Action arguments to the dev-mode (`pnpm dev`) terminal, so the raw `sk-...` key landed in dev stdout every time a developer verified locally. Route handlers do **not** log request bodies, so this PR closes that developer-class secret leak. Production was already unaffected (`pnpm build && pnpm start` terminal verified clean).
- The hook caller in `lib/hooks/use-key-lifecycle.ts` now POSTs to `/api/verify-key` with the key in the JSON body. `useTransition` still wraps the async — no React-level migration needed.
- DAL is untouched: `verifyAndStoreKey()` in `lib/data/auth.ts` still does the OpenAI ping + AES-256-GCM seal + cookie set.
- `hasVerifiedKeyAction` + `clearVerifiedKeyAction` stay as Server Actions — they take **no arguments**, so no payload is ever logged.
- `isSameOrigin` extracted from `app/api/chat/route.ts` to a new `lib/csrf.ts` so both routes import the same helper (DRY).

## Architecture

The new route mirrors `/api/chat` layer-for-layer, minus unseal (verify SEALS the key; chat UNSEALS it):

| # | Layer | Reuse | This route |
|---|---|---|---|
| 1 | Same-origin guard | `lib/csrf.ts` (new, extracted) | 403 on Origin mismatch |
| 2 | Per-IP rate limit | `lib/rate-limit.ts` (shared bucket with /api/chat) | 429 + `Retry-After` |
| 3 | Content-Length cap | Pattern from /api/chat | **1KB** (vs /api/chat's 8KB — verify body is max ~280 bytes) |
| 4 | JSON parse + zod | `verifyKeyRequestSchema` (new, wraps existing `verifyKeyInputSchema`) | 400 |
| 5 | DAL delegation | `verifyAndStoreKey()` (untouched) | OpenAI ping + seal + cookie |
| 6 | Response | `NextResponse.json(result, ...)` | 200 with `{ ok, message }` DTO |

## Hygiene

The route file's header carries an explicit comment: **never `console.log(body)` or any field of it.** `parsed.data.key` is passed once to `verifyAndStoreKey()` and immediately goes out of scope; the key never touches a log statement on this call path.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 7 warnings unchanged (pre-existing nursery class-sort, not introduced)
- [x] `pnpm test:run` — **20/22**. 11 new verify-key route tests pass. **2 pre-existing failures** in `tests/chat-route.test.ts:94,140` (assertion drift on main, unrelated — same red as PR #39 / #40)
- [x] `pnpm build` — clean: `/api/verify-key` appears in the route table
- [x] `pnpm test:e2e` — **2/2** pass in 9.4s (locked → verified → chat → disconnect + refresh-restore)
- [x] Production-mode visual smoke — verify path identical UX
- [x] **Dev-stdout key-leak smoke (THE goal)** — `pnpm dev` terminal logs show `POST /api/verify-key 200 in NNNms` only. **No raw `sk-...` key string anywhere.** Migration delivered its purpose.

## Known pre-existing red — NOT introduced by this PR

- `tests/chat-route.test.ts:94,140` — same assertion drift documented in PR #39 / #40 bodies. Separate test-backlog item.

## Test plan

- [ ] Deploy preview on Vercel
- [ ] Hit preview, verify a valid key → unlocks + chat works
- [ ] Verify an invalid key → error message, stays locked
- [ ] Disconnect → cookie cleared
- [ ] Confirm no regression on the locked → verified → chat → disconnect flow
- [ ] (Optional) `curl` cross-origin to `/api/verify-key` with `Origin: https://evil.example` → 403

Co-authored-by: Cursor <cursoragent@cursor.com>