### PR TITLE
fix(frontend): unify chat-shell responsive layout across all breakpoints

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -290,39 +290,41 @@
 
     /* Chat shell heights — drive the locked → unlocked expansion animation.
        Kept in `:root` (not `@theme`) because Tailwind v4 has no `height`
-       namespace; consumed via `var(...)` in the .chat-shell-frame @utility. */
+       namespace; consumed via `var(...)` in the .chat-shell-frame @utility.
+       --shell-h-unlocked = 100% resolves against the chat-shell <section>'s
+       flex-1 height when unlocked (see chat-shell.tsx). --shell-max-h-unlocked
+       = 100svh is effectively uncapped — bounded only by <main>'s `h-svh`.
+       Uniform across all breakpoints: same UX mobile → 2xl. */
     --shell-h-locked: clamp(320px, 44svh, 380px);
-    --shell-h-unlocked: 72svh;
-    --shell-max-h-unlocked: 820px;
+    --shell-h-unlocked: 100%;
+    --shell-max-h-unlocked: 100svh;
   }
 
   @media (min-width: 640px) {
     :root {
       --shell-h-locked: clamp(340px, 42svh, 400px);
-      --shell-h-unlocked: 74svh;
+      /* --shell-h-unlocked inherits 100% from :root */
     }
   }
 
   @media (min-width: 1024px) {
     :root {
       --shell-h-locked: clamp(360px, 40svh, 440px);
-      --shell-h-unlocked: 88svh;
-      --shell-max-h-unlocked: 960px;
+      /* --shell-h-unlocked inherits 100% from :root */
     }
   }
 
   @media (min-width: 1280px) {
     :root {
       --shell-h-locked: clamp(380px, 42svh, 460px);
-      --shell-h-unlocked: 90svh;
-      --shell-max-h-unlocked: 1020px;
+      /* --shell-h-unlocked inherits 100% from :root */
     }
   }
 
   @media (min-width: 1536px) {
     :root {
       --shell-h-locked: clamp(400px, 44svh, 480px);
-      --shell-max-h-unlocked: 1080px;
+      /* --shell-max-h-unlocked inherits 100svh from :root */
     }
   }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -24,7 +24,7 @@ export default async function HomePage() {
   return (
     <main
       id="main-content"
-      className="relative isolate min-h-svh overflow-y-auto overflow-x-hidden px-3 py-5 sm:px-4 sm:py-6 lg:h-svh lg:min-h-0 lg:overflow-hidden lg:px-8 lg:py-8 xl:px-10 xl:py-10"
+      className="relative isolate flex h-svh flex-col overflow-y-auto overflow-x-hidden px-3 py-5 sm:px-4 sm:py-6 lg:px-8 lg:py-8 xl:px-10 xl:py-10"
     >
       {/* "Love is the only answer" handwritten epigraphs flank the chat shell
           diagonally — upper-left + middle-right. Positioned with

--- a/frontend/components/chat/chat-shell.tsx
+++ b/frontend/components/chat/chat-shell.tsx
@@ -183,7 +183,15 @@ export function ChatShell({ initialIsApiKeyVerified }: ChatShellProps) {
   return (
     <>
       <CrowdSilhouette isVisible={key.isApiKeyVerified} />
-      <section className="relative flex min-h-0 w-full justify-center">
+      <section
+        className={cn(
+          "relative flex min-h-0 w-full justify-center",
+          // Grow into the remaining LayoutRoot space ONLY when unlocked.
+          // Locked stays auto-height so LayoutRoot's `justify-center` drives
+          // the compact-card vertical centering. Same UX at every breakpoint.
+          !isChatLocked && "min-h-0 flex-1"
+        )}
+      >
         <div
           className={cn(
             "chat-shell-frame w-full",
@@ -208,8 +216,10 @@ export function ChatShell({ initialIsApiKeyVerified }: ChatShellProps) {
                 // primitive auto-adds `chat-shell-glass` for the rest of the
                 // glass styling.
                 "backdrop-blur-[20px]",
-                "gap-3 p-3 sm:gap-4 sm:p-4 md:p-6",
-                !isChatLocked && "min-h-[520px]"
+                "gap-3 p-3 sm:gap-4 sm:p-4 md:p-6"
+                // No min-h: Card adapts to frame's flex-allocated height at
+                // every breakpoint. Composer is always pinned to Card bottom;
+                // MessageList scrolls internally via its own flex-1 min-h-0.
               )}
             >
               <ConnectionStatusCard

--- a/frontend/components/chat/locked-key-card.tsx
+++ b/frontend/components/chat/locked-key-card.tsx
@@ -87,7 +87,7 @@ export function LockedKeyCard({
       </p>
       <form
         onSubmit={handleSubmit}
-        className="grid w-full max-w-[560px] grid-cols-1 gap-2.5 sm:grid-cols-[1fr_auto] sm:gap-3"
+        className="grid w-full max-w-[560px] grid-cols-[1fr_auto] gap-2.5 sm:gap-3"
       >
         <Label htmlFor="openai-key" className="sr-only">
           OpenAI API key

--- a/frontend/components/layout/layout-root.tsx
+++ b/frontend/components/layout/layout-root.tsx
@@ -53,11 +53,15 @@ export function LayoutRoot({ initialIsApiKeyVerified, children }: LayoutRootProp
       <div
         data-layout-root
         className={cn(
-          "mx-auto flex w-full max-w-[1320px] flex-col gap-4 lg:h-full",
-          // Locked → whole content block centers vertically as a single group.
-          // Unlocked → DisclaimerWrapper pins the footer to viewport bottom
-          // via `lg:mt-auto`, so the chat shell expands at top.
-          isChatLocked && "lg:justify-center"
+          "mx-auto flex w-full max-w-[1320px] flex-1 flex-col gap-4",
+          // flex-1 fills <main> (which is now h-svh + flex flex-col at every
+          // breakpoint). Locked → justify-center vertically centers the
+          // content block when it fits; <main>'s overflow-y-auto handles
+          // shorter viewports where Hero + LockedKeyCard + Disclaimer exceed
+          // the viewport. Unlocked → no centering; the chat-shell <section>
+          // becomes flex-1 (see chat-shell.tsx) and grows to fill, pinning
+          // the composer to the bottom. Same UX at every breakpoint.
+          isChatLocked && "justify-center"
         )}
       >
         {children}


### PR DESCRIPTION
## Summary

Extends the lg+ chat-shell layout philosophy to every breakpoint (mobile through 2xl). The page architecture was discontinuous at the `lg` (1024px) seam: viewport-bounded with vertical centering and flex-grown shell above lg, scrollable + svh-relative below. This PR makes the layout uniform across all widths so mobile, tablet, and desktop users get the **same UX**:

- **Locked**: card vertically centered when content fits; `<main>`'s `overflow-y-auto` lets mobile scroll if Hero + LockedKeyCard + Disclaimer exceed viewport height.
- **Unlocked**: chat shell fills viewport, composer pinned to the bottom at every breakpoint.
- **Verify form**: input + Verify Key button **side-by-side at every width** (no mobile stack).

This is the actual Bug #1.8 root cause. The discrete `--shell-max-h-unlocked` height cap was a *symptom*; the root cause was the breakpoint-conditional layout architecture.

## Architecture

```
<main h-svh flex flex-col overflow-y-auto ...>          ← uniform at every breakpoint
  <LayoutRoot flex-1 flex flex-col + justify-center when locked>
    <Hero/>                                              ← natural size
    <ChatShell>
      <section flex-1 min-h-0 when unlocked>             ← grows to fill
        <.chat-shell-frame height: 100%>                  ← of section
          <Card>                                          ← no min-h: adapts to frame
    <DisclaimerWrapper/>                                 ← only when locked
```

Cross-state behavior (uniform at every breakpoint):

| State | LayoutRoot | Section | Frame | Card |
|---|---|---|---|---|
| Locked | `justify-center` | auto-height (= clamp) | `clamp(...)` | h-full of frame |
| Unlocked | default | `flex-1 min-h-0` | `100%` of section | h-full, no min |

The 720ms locked↔unlocked height transition stays smooth — both endpoints are definite pixel values at runtime.

## Changes (5 files, single concern)

- `app/page.tsx`: `<main>` uniform classes (`h-svh flex flex-col overflow-y-auto overflow-x-hidden ...`), drop `lg:h-svh lg:min-h-0 lg:overflow-hidden`
- `components/layout/layout-root.tsx`: add `flex-1`, drop `lg:` prefixes from `h-full` (replaced by flex-1) and `justify-center` (now uniform)
- `components/chat/chat-shell.tsx`: section gets `!isChatLocked && "min-h-0 flex-1"` (no `lg:` prefix); Card's `!isChatLocked && "min-h-[520px]"` removed
- `app/globals.css`: `--shell-h-unlocked: 100%` and `--shell-max-h-unlocked: 100svh` at `:root`; drop all stepped overrides at sm/lg/xl/2xl — uniform values
- `components/chat/locked-key-card.tsx`: form grid `grid-cols-[1fr_auto]` at every width (no mobile stack)

**Diff: 5 files, 35+/19−.**

## Trade-off — intentional, surfaced before merge

At common desktop viewports (e.g., 1280×800), Card's content area is now the flex-allocated value (~520-580px) rather than the prior `88svh` (~704px). MessageList's internal `flex-1 min-h-0 overflow-y-auto` handles message overflow gracefully. User accepted this trade-off explicitly during planning in exchange for layout consistency across all breakpoints.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 7 pre-existing warnings unchanged (no new)
- [x] `pnpm test:run` — 20/22 (same 2 pre-existing `tests/chat-route.test.ts:94,140` drifts, unrelated)
- [x] `pnpm build` — clean, all routes intact
- [x] `pnpm test:e2e` — **2/2 pass in 24.8s** (locked → verified → chat → disconnect + refresh-restore)
- [x] Local production-mode visual smoke — **all 16 checkpoints passed** across 7 viewports × 2 states + 2 transition cases + edge case

## Explicitly out of scope

- `concert-crowd.png` internal whitespace → Bug #1.9 (separate image-asset PR)
- `HeartDoodle` overlap with Locked badge → Bug #1.85 (separate decorative-reposition PR)
- Hero font cascade (`text-5xl → xl:text-[4.65rem]`) → design intent, preserved
- `max-w` cascade (`980 → lg:940 → xl:980 → 2xl:1040`) → design intent, preserved

## Test plan

- [ ] Deploy preview on Vercel
- [ ] Mobile (375 × 667 / 414 × 896): locked content stacks + scrolls if needed; unlocked shell fills viewport, composer at bottom; form input + button side-by-side
- [ ] Tablet portrait (768 × 1024): locked card vertically centered; unlocked composer at bottom
- [ ] Desktop (1280 × 800, 1280 × 1500, 1536 × 1340): locked centered; unlocked fills with composer at bottom — **the original Bug #1.8 cases**
- [ ] Lock→unlock and unlock→lock transitions smooth (720ms); shell-burst glow on verify
- [ ] No regression on chat functionality, audio gesture, music auto-start, hover/focus states

Co-authored-by: Cursor <cursoragent@cursor.com>