### PR TITLE
fix(frontend): verify-key glass + locked clamp fits stacked-form mobile

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -295,7 +295,7 @@
        flex-1 height when unlocked (see chat-shell.tsx). --shell-max-h-unlocked
        = 100svh is effectively uncapped — bounded only by <main>'s `h-svh`.
        Uniform across all breakpoints: same UX mobile → 2xl. */
-    --shell-h-locked: clamp(320px, 44svh, 380px);
+    --shell-h-locked: clamp(420px, 54svh, 460px);
     --shell-h-unlocked: 100%;
     --shell-max-h-unlocked: 100svh;
   }
@@ -689,8 +689,38 @@
    the Input uses) so the animated prism gradient border + height come from
    the wrapper. This class just establishes a stacking context for the
    button's interior surface. */
+/* Verify-key CTA inside `locked-input-ring`. Translucent dark glass that
+   lets the wrapper's rainbow gradient show through — same visual treatment
+   as the shadcn Input next to it (Input is `bg-transparent` so the wrapper
+   rainbow reads through fully). Button is darker (translucent slate) so the
+   bold cyan CTA text reads clearly without breaking the colorful family.
+   Layered:
+     1. translucent slate body (~50% — lets ~half the rainbow through)
+     2. backdrop-blur softens the rainbow underneath for text legibility
+     3. Apple Liquid Glass inset top sheen (1px white)
+     4. subtle inset edge (1px white at low alpha) for depth
+     5. soft cyan outer glow — same aurora-cyan family as chat-shell-glass
+   Hover deepens the cyan accents (border + glow) without darkening the bg. */
 @utility locked-verify-btn {
   position: relative;
+  background: linear-gradient(140deg, rgba(2, 6, 23, 0.55) 0%, rgba(2, 6, 23, 0.4) 100%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 0 18px rgba(125, 249, 255, 0.12);
+  transition:
+    background 200ms ease,
+    box-shadow 200ms ease;
+
+  &:hover {
+    background: linear-gradient(140deg, rgba(15, 23, 42, 0.55) 0%, rgba(2, 6, 23, 0.4) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.24),
+      inset 0 0 0 1px rgba(125, 249, 255, 0.2),
+      0 0 24px rgba(125, 249, 255, 0.24);
+  }
 }
 
 /* Outer chat shell: DARK glass — the content well. Light hero + bright aurora

--- a/frontend/components/chat/locked-key-card.tsx
+++ b/frontend/components/chat/locked-key-card.tsx
@@ -112,8 +112,9 @@ export function LockedKeyCard({
         <div className="locked-input-ring">
           <Button
             type="submit"
+            variant="ghost"
             disabled={isVerifyingKey || apiKeyInput.trim().length === 0}
-            className="locked-verify-btn h-12 w-full border-0 bg-slate-950 px-7 font-semibold text-base text-cyan-300 shadow-none hover:bg-slate-900 hover:text-cyan-200 disabled:opacity-90"
+            className="locked-verify-btn h-12 w-full border-0 px-7 font-bold text-base text-cyan-300 [text-shadow:0_1px_3px_rgba(0,0,0,0.6)] hover:text-cyan-200 disabled:opacity-90"
           >
             {isVerifyingKey ? "Verifying..." : "Verify key"}
           </Button>


### PR DESCRIPTION
## Summary

Two coupled mobile-landing fixes after PR #43 visual smoke surfaced clashes.

### 1. Verify Key button — match the Input's translucent treatment

**Root cause:** The Button's default `variant="default"` applies the `aurora-button` `@utility` (white→cyan→amber gradient + dark navy text via `background:` shorthand). My earlier cyan-300 text override gave cyan-on-light = unreadable. Replacing with solid `bg-slate-950` gave a dark void next to the Input's translucent rainbow — visually mismatched.

**Fix:** Mirror the Input's treatment. shadcn Input is `bg-transparent`, so the `locked-input-ring` rainbow shows through fully. The button now uses **translucent dark glass** over the wrapper rainbow — same visual family as the Input, dark enough that bold cyan-300 text with drop-shadow reads cleanly.

Real `locked-verify-btn` `@utility` (previously an empty `{ position: relative }` stub):
- Translucent slate body (50% — lets ~half the rainbow show)
- `backdrop-filter: blur(8px)` softens the rainbow for text legibility
- Apple Liquid Glass top sheen (1px white inset)
- Subtle inner edge (1px white at low alpha) for depth
- Soft cyan outer glow (aurora-cyan family — matches `chat-shell-glass`)
- Hover deepens the cyan inset border + outer glow

`<Button>` className simplifies — `variant="ghost"` (drops aurora-button), `font-bold text-cyan-300 [text-shadow:...]`, drops the now-redundant `bg-slate-950`, `shadow-none`, `hover:bg-slate-900`.

### 2. Locked-state shell clamp accommodates the stacked form

Bug #1.8 v3 + #43 restored `grid-cols-1 sm:grid-cols-[1fr_auto]` — input + button stacked on mobile, side-by-side on sm+. The stacked layout adds ~58px (extra row + gap) vs side-by-side. The locked-state `--shell-h-locked` clamp `clamp(320px, 44svh, 380px)` was sized for the side-by-side layout. With stacked form + a 2-line `keyFeedback` + the `Server-side validation` footer, content exceeded 380px and clipped on iPhone-class viewports.

Bumped `:root --shell-h-locked` to `clamp(420px, 54svh, 460px)` — base mobile only. sm+ stays at `clamp(340px, 42svh, 400px)` since it has the compact side-by-side form.

## Files (2)

- `frontend/app/globals.css` — real `locked-verify-btn` utility + locked clamp bump
- `frontend/components/chat/locked-key-card.tsx` — `variant="ghost"`, font-bold + text-shadow, drop redundant bg/shadow utilities

**Diff: 2 files, +33/−2.**

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 9 warnings (no errors; pre-existing nursery + 2 from in-flight coupled edits, FIXABLE class-sort)
- [x] `pnpm test:run` — 20/22 (same pre-existing chat-route drift)
- [x] `pnpm build` — clean
- [x] `pnpm test:e2e` — 2/2 pass (1 retry-flake within retries:2 budget from #36)
- [x] Local production-mode visual smoke — button matches Input's translucent rainbow family, validation footer no longer clipped on mobile

## Test plan

- [ ] Deploy preview on Vercel
- [ ] iPhone 14 Pro mobile: Verify Key button shows translucent dark glass over the locked-input-ring rainbow (matches Input visual treatment); `Server-side validation. Never stored in browser.` text fully visible (not clipped)
- [ ] iPad portrait (768×1024): form goes side-by-side, button looks coherent with input
- [ ] Desktop ≥1024: same — button reads as part of the rainbow family

Co-authored-by: Cursor <cursoragent@cursor.com>