### PR TITLE
fix(frontend): wire audio kick-off to LockedKeyCard pointerdown for iOS gesture

### DIFF
--- a/frontend/components/chat/locked-key-card.tsx
+++ b/frontend/components/chat/locked-key-card.tsx
@@ -66,6 +66,17 @@ export function LockedKeyCard({
   return (
     <section
       aria-label="OpenAI key verification"
+      // Fire the audio-unlock kick-off on the FIRST tap anywhere inside
+      // the locked card — not just on form submit. The `useSoundExperience`
+      // window listener handles desktop reliably, but on iOS Safari/Brave
+      // `touchstart` on an `<input type="password">` is preempted by the
+      // input's focus + virtual-keyboard handling and doesn't reach
+      // `window` listeners (especially with `{ passive: true }`). Direct
+      // `onPointerDown` here runs synchronously in the user-gesture frame,
+      // matching the path that already works for the Verify Key click
+      // (handleSubmit → onBeforeSubmit). Idempotent — sound.startCrowd's
+      // internal advancePhase guard skips after the first call.
+      onPointerDown={() => onBeforeSubmit?.()}
       className={cn(
         "flex flex-col items-center gap-3 px-2 py-2 text-center sm:gap-4 sm:py-4",
         isSwappingPanel ? "panel-exit" : isEntering ? "panel-enter" : null


### PR DESCRIPTION
## Summary

iOS-specific fix: tapping the `sk-...` input field on iPhone/iPad never started the crowd ambience. Only the Verify Key click (form submit path) unlocked audio. Desktop works fine because mouse `pointerdown` bubbles to the `window` listener.

## Root cause

`useSoundExperience` (`lib/hooks/use-sound-experience.ts:121-143`) attaches `pointerdown` / `touchstart` / `keydown` listeners on `window` with `{ passive: true }` to start crowd on the first user gesture.

**On iOS Safari/Brave**, `touchstart` on an `<input type="password">` is preempted by the input's own focus + virtual-keyboard handling — it doesn't reliably bubble to `window` listeners, especially passive ones. Result: the first-gesture audio unlock missed the input tap entirely.

The Verify Key click works because the form's `handleSubmit` calls `onBeforeSubmit?.()` directly inline (no window-listener dependency), inside the user-gesture frame.

## Fix

Attach `onPointerDown` directly on the `<LockedKeyCard>` `<section>` calling the same `onBeforeSubmit?.()` handler. Any tap inside the locked card (input, sound pill, headline, button area) now runs the audio kick-off synchronously inside the user-gesture frame — same proven path as the Verify Key click.

`sound.startCrowd` is idempotent (advancePhase + `AudioOrchestrator` source/buffer reuse), so repeated taps are safe no-ops after the first.

## Changes (1 file)

- `frontend/components/chat/locked-key-card.tsx` — `onPointerDown={() => onBeforeSubmit?.()}` on the outer `<section>`

**Diff: 1 file, +11/0** (mostly the explanatory comment).

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 9 warnings unchanged (pre-existing + coupled in-flight)
- [x] `pnpm build` — clean
- [x] `pnpm test:e2e` — 2/2 pass in 9.6s

## Test plan

- [ ] Deploy preview on Vercel
- [ ] **iPhone**: open production preview, tap the `sk-...` input field → **crowd ambience should start immediately** (was waiting until Verify Key click)
- [ ] Desktop: tap input → crowd starts (regression check — was working, must still work)
- [ ] Tapping sound pill, headline, or any other area inside locked card also kicks off crowd

Co-authored-by: Cursor <cursoragent@cursor.com>