### PR TITLE
polish(frontend): mobile layout — single status slot, shorter copy, error contrast

### DIFF
--- a/frontend/components/chat/chat-composer.tsx
+++ b/frontend/components/chat/chat-composer.tsx
@@ -76,11 +76,7 @@ export function ChatComposer({
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder={
-          isDisabled
-            ? "Verify key above to begin"
-            : "Ask about Coldplay... (Enter to send, Shift+Enter for newline)"
-        }
+        placeholder={isDisabled ? "Verify key above to begin" : "Ask about Coldplay..."}
         rows={1}
         disabled={isLoading || isDisabled}
         // `min-h-0` overrides the base Textarea's min-h-[64px] which was

--- a/frontend/components/chat/locked-key-card.tsx
+++ b/frontend/components/chat/locked-key-card.tsx
@@ -94,7 +94,7 @@ export function LockedKeyCard({
           user sees it before clicking Verify. */}
       <p className="mt-2 mb-2 inline-flex items-center gap-2 rounded-full border border-cyan-300/35 bg-cyan-300/8 px-4 py-1.5 font-medium text-yellow-200 text-sm shadow-[0_0_20px_rgba(125,249,255,0.18)] [text-shadow:0_1px_2px_rgba(0,0,0,0.45)] sm:mt-3 sm:mb-3 sm:gap-2.5 sm:px-5 sm:py-2 sm:text-base">
         <Volume2 aria-hidden className="h-4 w-4 shrink-0 sm:h-4.5 sm:w-4.5" />
-        <span className="italic">Turn on your device sound for the full experience.</span>
+        <span className="italic">Turn on sound for the full experience.</span>
       </p>
       <form
         onSubmit={handleSubmit}
@@ -136,20 +136,21 @@ export function LockedKeyCard({
           id="key-feedback"
           role={isApiKeyVerified ? "status" : "alert"}
           className={cn(
-            "m-0 font-semibold text-sm",
+            "m-0 font-semibold text-sm [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]",
             keyFeedbackTone === "success"
               ? "text-emerald-200"
               : keyFeedbackTone === "error"
-                ? "text-red-200 animate-pulse duration-400"
+                ? "text-red-300 animate-pulse duration-400"
                 : "text-slate-100"
           )}
         >
           {keyFeedback}
         </p>
-      ) : null}
-      <p className="m-0 max-w-[44ch] text-lime-300 [text-shadow:0_0_10px_rgba(190,242,100,0.45)] text-xs italic leading-relaxed">
-        Server-side validation. Never stored in browser.
-      </p>
+      ) : (
+        <p className="m-0 max-w-[44ch] text-lime-300 [text-shadow:0_0_10px_rgba(190,242,100,0.45)] text-xs italic leading-relaxed">
+          Server-side validation. Never stored in browser.
+        </p>
+      )}
     </section>
   );
 }

--- a/frontend/lib/hooks/use-key-lifecycle.ts
+++ b/frontend/lib/hooks/use-key-lifecycle.ts
@@ -129,7 +129,7 @@ export function useKeyLifecycle({
         setInputValue("");
         setApiKeyInput("");
         setIsApiKeyVerified(false);
-        setKeyFeedback("Secure key session cleared. Please verify a key to continue.");
+        setKeyFeedback("Session cleared — verify a new key to continue.");
         setKeyFeedbackTone("info");
         clearPersistedState();
         setIsSwappingPanel(false);

--- a/frontend/tests/e2e/session-persistence.spec.ts
+++ b/frontend/tests/e2e/session-persistence.spec.ts
@@ -121,9 +121,7 @@ test("disconnect clears cookie-backed session state and client persistence", asy
 
   await page.getByRole("button", { name: "Disconnect verified key" }).click();
 
-  await expect(
-    page.getByText("Secure key session cleared. Please verify a key to continue.")
-  ).toBeVisible();
+  await expect(page.getByText("Session cleared — verify a new key to continue.")).toBeVisible();
   await expect(page.getByRole("region", { name: "OpenAI key verification" })).toBeVisible();
 
   await page.reload();

--- a/frontend/tests/walkthrough/walkthrough.spec.ts
+++ b/frontend/tests/walkthrough/walkthrough.spec.ts
@@ -97,9 +97,7 @@ test.describe("chat-shell visual walkthrough", () => {
 
     // ── 06. After disconnect ─────────────────────────────────────────────
     await page.getByRole("button", { name: "Disconnect verified key" }).click();
-    await expect(
-      page.getByText("Secure key session cleared. Please verify a key to continue.")
-    ).toBeVisible();
+    await expect(page.getByText("Session cleared — verify a new key to continue.")).toBeVisible();
     // Allow panel-swap to settle.
     await page.waitForTimeout(400);
     await page.screenshot({


### PR DESCRIPTION
## Summary

Five demo-path mobile fixes ahead of submission, bundled as one atomic PR because all share a single user-visible outcome: the locked-key card and chat composer no longer pinch, wrap, or hide content on iPhone-class viewports.

- **Single status slot** in `LockedKeyCard` — replaces the sibling-stacked feedback + assurance `<p>` pair that was pushing "Server-side validation..." off the visible card on mobile after Disconnect. One DOM position, predictable height envelope, no overflow.
- **Error feedback contrast bump** — `text-red-200` was perception-invisible over the rainbow-gradient glass on mobile. Now `text-red-300` + `[text-shadow:0_1px_3px_rgba(0,0,0,0.55)]` matches the family of other text-shadows in the card. Pulse animation logic unchanged.
- **"Turn on sound" pill copy** — 50ch → 38ch, fits one line at 375px without responsive-only hacks.
- **Cleared-session message copy** — 60ch → 47ch with em-dash transition. Two e2e assertion strings updated to match.
- **Chat composer placeholder** — 62ch → 21ch. Keyboard-shortcut hints removed (they don't apply on iOS soft keyboards anyway; Sparkles button is the discoverable affordance).

Universality principle preserved throughout: every change applies to all devices — no mobile-only branching.

## Test plan

- [ ] Vercel preview deploys green
- [ ] Locked card, mobile (375px / actual iPhone): "Turn on sound..." pill on ONE line
- [ ] Verify with intentionally-invalid key: pulse-red error message visible against rainbow background
- [ ] Click Disconnect: "Session cleared — verify a new key to continue." appears WITHOUT pushing assurance line off the card
- [ ] Start typing new key: cleared message disappears, assurance line returns
- [ ] Chat shell (post-verify) on mobile: composer placeholder "Ask about Coldplay..." on ONE line
- [ ] Typed prompt in composer behaves as before
- [ ] Desktop: all of the above still readable / non-regressed
- [ ] `pnpm typecheck` clean
- [ ] `pnpm build` clean
- [ ] No NEW lint warnings introduced (4 pre-existing nursery class-sort untouched, handled in dedicated hygiene PR)
- [ ] No NEW test failures (only pre-existing `chat-route.test.ts:94,140` drift from #36, handled in dedicated hygiene PR)