### PR TITLE
fix(frontend): mobile refresh now restores verified key session

### DIFF
--- a/frontend/lib/data/auth.ts
+++ b/frontend/lib/data/auth.ts
@@ -54,9 +54,19 @@ export async function verifyAndStoreKey(key: string): Promise<VerifyKeyResult> {
       cookieStore.set(OPENAI_API_KEY_COOKIE, seal(key), {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
-        // strict (not lax): cross-site navigation must NOT carry this
-        // key cookie. App is single-origin; strict has zero UX cost.
-        sameSite: "strict",
+        // lax (not strict): iOS Safari + Brave apply a stricter
+        // interpretation of `strict` than Chromium does — top-level
+        // refresh on a freshly-verified session can be classified as
+        // cross-site and the cookie is withheld, kicking the user back
+        // to the locked card. `lax` permits top-level same-site
+        // navigation (refresh, direct link, back button) while still
+        // blocking the only CSRF vector that matters here: cross-site
+        // POST. That vector is already double-guarded by the
+        // `isSameOrigin` check in /api/verify-key/route.ts and
+        // /api/chat/route.ts, so the net security delta vs strict is
+        // zero. Matches OWASP's modern default for httpOnly + secure
+        // session cookies.
+        sameSite: "lax",
         path: "/",
         maxAge: SESSION_TTL_SECONDS,
       });

--- a/frontend/tests/e2e/session-persistence.spec.ts
+++ b/frontend/tests/e2e/session-persistence.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ context, page }) => {
       value: KEY_COOKIE_VALUE,
       url: TEST_BASE_URL,
       httpOnly: true,
-      sameSite: "Strict",
+      sameSite: "Lax",
     },
   ]);
 

--- a/frontend/tests/walkthrough/walkthrough.spec.ts
+++ b/frontend/tests/walkthrough/walkthrough.spec.ts
@@ -63,7 +63,7 @@ test.describe("chat-shell visual walkthrough", () => {
         value: KEY_COOKIE_VALUE,
         url: TEST_BASE_URL,
         httpOnly: true,
-        sameSite: "Strict",
+        sameSite: "Lax",
       },
     ]);
     await page.reload();


### PR DESCRIPTION
## Summary

**Bug:** iPhone Safari + Brave kicked the user back to the locked card on every refresh after key verification. Desktop browsers persisted the session correctly.

**Root cause:** Key cookie was set with `sameSite: "strict"`. iOS WebKit applies a stricter interpretation than Chromium does — top-level same-origin refresh of a freshly-verified session can be classified as cross-site, and the cookie is withheld from the refresh request. SSR's `cookies()` sees nothing → `initialIsApiKeyVerified: false` → locked card renders.

**Fix:** Switch to `sameSite: "lax"`. One word in one file.

| Vector | strict | lax |
|---|---|---|
| Top-level refresh on same origin | iOS withholds | ✓ sent |
| Cross-site POST (CSRF) | blocked | blocked |
| Cross-site GET embed | blocked | blocked |

**Net security delta vs strict: zero.** Cross-site POSTs are already double-guarded by `isSameOrigin` at the request boundary in both `/api/verify-key/route.ts` and `/api/chat/route.ts`, so cookie attachment in cross-site contexts was already irrelevant to whether those endpoints accept the request. `lax` is OWASP's modern default for httpOnly+secure session cookies.

**Comment rewritten** in `auth.ts` to document the new rationale — the previous "strict has zero UX cost" claim was proven wrong on iOS, which is the bug this fixes.

**Test parity:** Both e2e fixture cookies (`session-persistence.spec.ts`, `walkthrough.spec.ts`) updated from `sameSite: "Strict"` to `"Lax"` so the test posture matches production. Tests would pass either way (refresh is same-origin in both modes); parity matters for honesty.

## Test plan

- [ ] Vercel preview deploys green
- [ ] **Mobile flow (iPhone Safari):** verify a key → refresh → still verified (chat shell visible, locked card NOT shown)
- [ ] **Mobile flow (iPhone Brave):** same
- [ ] **Mobile flow with active chat:** verify → send a message → refresh → key still verified, chat shell still rendered
- [ ] **Desktop regression check:** verify → refresh → still verified (existing e2e covers this; just confirm visually)
- [ ] **Disconnect → refresh:** locked card with no key, no spurious "logged in" flash
- [ ] **Safari Web Inspector (iPhone):** After verify, Storage → Cookies shows `openai_api_key` with `SameSite=Lax`. After refresh, `Cookie:` header on the page request includes `openai_api_key=…`
- [ ] `pnpm typecheck` clean
- [ ] `pnpm build` clean
- [ ] No new lint warnings (4 pre-existing nursery untouched, handled in dedicated hygiene PR)
- [ ] No new test failures (only pre-existing `chat-route.test.ts:94,140` drift from #36, handled in dedicated hygiene PR)