### PR TITLE
feat(frontend): swap default fonts to Vercel Geist Sans + Geist Mono

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,6 +2,19 @@
 @import "tw-animate-css";
 
 /* ─────────────────────────────────────────────────────────────────────────
+   Font tokens — Geist Sans + Geist Mono wired to next/font/google variables
+   injected on <html> via app/layout.tsx. `@theme inline` substitutes these
+   into Tailwind's font-sans / font-mono utilities at build time, so every
+   `font-sans` / `font-mono` class anywhere in the app resolves to Geist.
+   The `inline` keyword keeps Tailwind from re-declaring the CSS variable
+   itself; the variable's runtime value is whatever next/font set on <html>.
+   ───────────────────────────────────────────────────────────────────────── */
+@theme inline {
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
    Design tokens — Tailwind v4 @theme directive.
 
    Color tokens auto-expose as Tailwind utilities (bg-bg-warm, text-aurora-cyan,
@@ -337,7 +350,9 @@
     margin: 0;
     padding: 0;
     min-height: 100%;
-    font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family:
+      var(--font-geist-sans), "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial,
+      sans-serif;
     color: var(--color-text-primary);
     /* Cinematic vignette: daylight center where the hero + chat live, indigo
        deepening toward the edges. Aurora blobs add diffuse rainbow glow that

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,8 +1,28 @@
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
+
+// Vercel's Geist Sans + Mono — self-hosted via next/font/google (build-time
+// download + subset, zero runtime CDN dep). `display: "swap"` shows the
+// system fallback immediately and swaps to Geist when ready — no FOIT, no
+// CLS from font-metric mismatch. The `variable` option injects the CSS
+// custom property onto <html>; Tailwind v4's @theme inline block in
+// globals.css maps it to --font-sans / --font-mono so every `font-sans` /
+// `font-mono` utility resolves to Geist.
+const geistSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist-sans",
+  display: "swap",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+  display: "swap",
+});
 
 const SITE_NAME = "Coldplay AI Companion";
 const SITE_DESCRIPTION =
@@ -65,7 +85,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
       {/* Browser extensions (ColorZilla `cz-shortcut-listen`, 1Password,
           Grammarly, dark-reader, etc.) inject `<body>` attributes between
           SSR and hydration. suppressHydrationWarning silences ONLY the


### PR DESCRIPTION
## Summary

Replaces the system-font fallback chain (Inter → SF Pro Text → Segoe UI → Roboto → Helvetica → Arial → sans-serif) with Vercel's purpose-built **Geist** as the primary face, falling back to the previous stack. Geist is optimized for code + UI surfaces (open-source, by the Vercel design team) and visibly elevates the typography from the generic "system PC" look the previous stack produced on Windows.

## Changes

### `app/layout.tsx`
- Import `Geist` + `Geist_Mono` from `next/font/google`
- Construct each with `subsets: ["latin"]`, `display: "swap"` (no FOIT), `variable: "--font-geist-{sans,mono}"`
- Apply both `className` variables to `<html>` so the CSS variables cascade across the whole tree

`display: "swap"` is the FCP/CLS-friendly default — system fallback shows immediately, swaps to Geist on load. `next/font`'s automatic local fallback metrics keep CLS near-zero through the swap.

### `app/globals.css`
- New `@theme inline` block at the top wiring Tailwind v4 design tokens `--font-sans` / `--font-mono` to the `next/font` CSS variables injected on `<html>`. Every `font-sans` / `font-mono` utility throughout the app now resolves to Geist at build time.
- Hardcoded body `font-family` updated to lead with `var(--font-geist-sans)` followed by the existing fallback chain. Explicit declaration remains so the cascade is provably Geist-first even if any future descendant resets `font-family`.

## Architecture properties

- **Self-hosted** via `next/font`'s build-time download — zero runtime Google CDN dependency, no third-party request in the network waterfall, no extra `connect-src` CSP entry needed
- **Zero new dependency** — `next/font/google` is part of Next.js core
- **No breaking change** — existing typography utilities, CSS variables, and font-family declarations continue to work; Geist is additive on top
- **Backwards-compatible fallback chain** preserved — Inter → SF Pro Text → Segoe UI → Roboto → Helvetica → Arial → sans-serif still kicks in if Geist ever fails to subset for an exotic locale

## Test plan

- [ ] Vercel preview deploys green
- [ ] Open Vercel preview on **desktop** → typography reads with Geist's distinctive geometric clarity (compare to current production's Helvetica/Arial)
- [ ] Open on **mobile Safari** → same Geist rendering, no fallback flash
- [ ] DevTools → Network → confirm Geist woff2 served from same-origin (`/_next/static/media/…`), no `fonts.gstatic.com` request
- [ ] DevTools → Console → no font-loading warnings
- [ ] DevTools → Lighthouse → CLS still < 0.1 (font swap should be near-zero shift thanks to next/font's auto-fallback metrics)
- [ ] `pnpm typecheck` clean (verified locally)
- [ ] `pnpm biome check` clean on changed files (verified locally — auto-format applied to multi-line font-family declaration)
- [ ] `pnpm test:run` 22/22 pass (verified locally)
- [ ] `pnpm build` clean, route surface unchanged (verified locally)