### PR TITLE
fix(frontend): surface audio failures via console.warn + reposition HeartDoodle off the Locked pill

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -56,10 +56,16 @@ export default async function HomePage() {
         size={40}
         className="absolute top-[10%] left-[6%] z-1 hidden rotate-6 opacity-85 lg:block"
       />
+      {/* Position rationale: at md / lg the chat shell is essentially
+          full-width with only thin gutter — there's no off-shell horizontal
+          zone for a decoration. Hide there. At xl+ the shell is capped at
+          ~980px so the viewport gutters can host the doodle off-shell. The
+          earlier `top-[36%] right-[4%]` landed ON the chat-header at every
+          breakpoint, overlapping the Locked status pill. */}
       <HeartDoodle
         variant="red"
         size={32}
-        className="absolute top-[36%] right-[4%] z-10 hidden rotate-12 opacity-80 md:block"
+        className="absolute top-[20%] right-[2%] z-10 hidden rotate-12 opacity-80 xl:block 2xl:right-[1%]"
       />
 
       <AuroraBackground />

--- a/frontend/lib/audio/audio-orchestrator.ts
+++ b/frontend/lib/audio/audio-orchestrator.ts
@@ -153,9 +153,12 @@ export class AudioOrchestrator {
         SOUND_TRACKS.crowd.crowdEntryFadeMs,
         ctx
       );
-    } catch {
+    } catch (error) {
       // Web Audio unavailable, buffer load failure, autoplay rejected —
       // surface silence rather than crash. Caller can't recover from here.
+      // Log so the failure is debuggable rather than silently swallowed —
+      // a previous incident burned an hour because this path was opaque.
+      console.warn("[audio] startCrowd failed:", error);
       return;
     }
   }
@@ -200,8 +203,10 @@ export class AudioOrchestrator {
           // Already disconnected by destroy() — fine.
         }
       });
-    } catch {
-      // Buffer load / decode failed or context lost — silence is fine.
+    } catch (error) {
+      // Buffer load / decode failed or context lost — silence is fine, but
+      // log so a recurring failure is visible in dev tools instead of mute.
+      console.warn("[audio] playBoo failed:", error);
       return;
     }
   }
@@ -217,7 +222,11 @@ export class AudioOrchestrator {
       this.music.currentTime = 0;
       try {
         await this.music.play();
-      } catch {
+      } catch (error) {
+        // play() rejection (autoplay-blocked / network / 502 from
+        // /api/audio/aerophonia). Log so prod-music incidents surface
+        // in DevTools instead of resolving to opaque silence.
+        console.warn("[audio] music.play() rejected:", error);
         return;
       }
     }
@@ -283,7 +292,10 @@ export class AudioOrchestrator {
         await this.music.play();
         await this.fadeElement(this.music, SOUND_TRACKS.music.targetVolume, durationMs);
       }
-    } catch {
+    } catch (error) {
+      // resume() rejection (audio element released, autoplay-blocked
+      // post-unmute). Log so unmute failures are visible.
+      console.warn("[audio] resume failed:", error);
       return;
     }
   }


### PR DESCRIPTION
## Summary

Two pre-existing polish items that were skipped during the model selector sprint. Atomic, no functional behavior changes — just **observability** + **visual hygiene**.

## A1 — Surface silent audio failures (4 catch sites)

Four `} catch { return; }` sites in \`lib/audio/audio-orchestrator.ts\` swallowed errors with zero observability:

| Line | Operation | What was swallowed |
|---|---|---|
| **156** | \`startCrowd\` | Web Audio init / buffer load failures |
| **203** | \`playBoo\` | Boo SFX buffer / decode failures |
| **220** | \`startMusic\` | \`music.play()\` rejection (autoplay-blocked, network, upstream 502 from \`/api/audio/aerophonia\`) |
| **286** | \`resume\` | Post-unmute play / fade failures |

Each now emits \`console.warn("[audio] <op> ...", error)\` before returning silently. **Runtime contract unchanged** (audio failures still resolve to silence rather than crashing the chat) — but failures are now debuggable.

A prior incident burned an hour because the \`music.play()\` rejection path was opaque (the Vercel Blob 502 surfaced as silence). This is the documented fix from that postmortem.

## A2 — HeartDoodle no longer overlaps the Locked status pill

\`app/page.tsx:59-63\`. The third decoration heart was anchored at \`top-[36%] right-[4%]\` with \`md:block\`, which lands directly on the chat-shell's top-right corner — i.e., **on top of the Locked pill in locked state** and **on top of the Disconnect button in verified state**, at every breakpoint that rendered it.

Repositioned to \`top-[20%] right-[2%]\` and visibility raised to \`xl:block\` (with \`2xl:right-[1%]\` for the widest viewports).

**Rationale:** at md and lg the shell is essentially full-width, so there is no off-shell horizontal zone for a decoration to live in. At xl+ the shell is capped (~980px max-width) so the viewport gutters can host the doodle clear of the chat surface.

## Gates

- 2 files changed, +24 / -6
- typecheck / biome / **29/29 tests** / production build all clean
- No API surface changes, no test changes needed

## Test plan

- [ ] DevTools console: trigger an audio failure (block \`/api/audio/aerophonia\`) → see \`[audio] music.play() rejected: ...\` instead of opaque silence
- [ ] Visual: locked card on md / lg viewports → HeartDoodle is hidden (no overlap with Locked pill)
- [ ] Visual: locked card on xl+ viewports → HeartDoodle visible in the right gutter, clear of the shell
- [ ] Vercel preview matches local