### PR TITLE
docs(readme): catch up submission-day Adjustments + frontend hook/test counts + Model Selector / Tooltip / RTL subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Then rerun your vibe check and document:
 ---
 
 **Adjustments Made:**  
-Five PRs shipped on submission day, bundling functional fixes, a feature addition, and W3C-grade architectural compliance:
+Nine PRs shipped on submission day, bundling functional fixes, two new features (crowd-booing reaction + model selector), a comprehensive accessibility upgrade (Tooltip system), W3C-grade architectural compliance, and FAANG-grade test infrastructure:
 
 | PR | Change | User-visible outcome |
 |---|---|---|
@@ -367,11 +367,16 @@ Five PRs shipped on submission day, bundling functional fixes, a feature additio
 | **#48** | Cookie `sameSite: "strict"` → `"lax"` for iOS WebKit compliance | iPhone refresh now restores the verified session (was bouncing users back to the locked card — Chromium worked, iOS WebKit applied stricter SameSite semantics on top-level refresh). |
 | **#49** | P2 hygiene sweep — test drift cleared, 9 `nursery/useSortedClasses` warnings auto-fixed | CI went from 20/22 + 9 warnings → **22/22 + 0 warnings**. |
 | **#50** | W3C autoplay-policy spec §3.2.2 compliance — synchronous gesture-time `AudioContext` unlock | Chrome's *"AudioContext was not allowed to start"* informational console log is suppressed via spec-compliant sync construction inside the gesture frame; audio orchestration is now textbook-compliant. |
+| **#53** | Locked-state status dot color bug fix (third semantic case via new `isLocked` prop) + introduction of **RTL + jsdom component-test infrastructure** with a `// @vitest-environment jsdom` opt-in pragma | The status dot now reads **red until validation passes** (was rendering green as soon as `hasError` was false, including the locked-no-error state); foundation in place for FAANG-grade component testing across the codebase. |
+| **#54** | **shadcn `Tooltip` system** — primitive + root `<TooltipProvider>` + applied across SoundToggle, Sparkles, Send, Stop, Disconnect, Verify Key, model selector trigger | Every icon-only / action control now has an **accessible, keyboard-focusable, mobile-friendly** hint (replaces inconsistent native `title=` attributes which are a no-op on touch devices). |
+| **#55** | **NEW FEATURE:** persistent in-app **model selector** — Fast (`gpt-5-mini`) / Balanced (`gpt-5`) / Advanced (`gpt-5.5`) — backed by a single `MODELS` constant, zod allowlist on `/api/chat`, per-model token caps, `localStorage`-persisted preference | Users can choose the model from the composer; selection survives reloads and Disconnect (UI preference, not conversation data). Reasoning models get the headroom they need (env default `OPENAI_MAX_COMPLETION_TOKENS` raised 1500 → 4000). |
+| **#56** | `console.warn` sweep across 4 silent `} catch { return; }` sites in `audio-orchestrator.ts` + HeartDoodle reposition off the Locked status pill | Audio failures (autoplay-blocked, upstream 502, decode errors) are now **visible in DevTools** rather than resolving to opaque silence; HeartDoodle no longer overlaps the chat-shell's top-right corner at md / lg viewports. |
 
 **Results:**  
 - **Mobile parity** — iPhone Safari + Brave now match desktop behavior end-to-end (audio kick-off on input tap, session persistence across refresh, status-message layout fit).
-- **Console cleanliness** — production console is fully clean after enabling Vercel Web Analytics on the dashboard (the only remaining warnings were config-drift, not code bugs).
-- **Engineering health** — `pnpm typecheck` clean, `pnpm biome check` 0 warnings, `pnpm test:run` 22/22 pass, `pnpm build` clean. **Zero tech debt introduced; pre-existing debt cleared.**
+- **Console cleanliness** — production console is fully clean after enabling Vercel Web Analytics on the dashboard (the only remaining warnings were config-drift, not code bugs). Audio failure paths now emit `console.warn` with the originating error so they're debuggable rather than silent.
+- **Engineering health** — `pnpm typecheck` clean, `pnpm biome check` 0 warnings, `pnpm test:run` **29/29 pass** (was 22/22 — +4 component tests for the locked-dot truth table, +3 chat-route model-validation cases), `pnpm build` clean. **Zero tech debt introduced; pre-existing debt cleared.**
+- **A11y posture** — every interactive control now exposes a shadcn `Tooltip` (Radix-handled focus + ARIA) instead of inconsistent native `title=`. Status dot color contract covered by a 4-case truth-table component test.
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,7 +13,7 @@ That's the first thing the chat types out — three lines, one character at a ti
 A love letter to **Coldplay** wrapped in a security-hardened streaming chat. Built as the capstone of the [**AI Maker Space — AI Engineering Challenge**](https://github.com/AI-Maker-Space/The-AI-Engineer-Challenge). Non-commercial, educational fair use — the band is the subject of the project, not its sponsor.
 
 <p align="center">
-  <code>22/22 tests</code> · <code>0 lint warnings</code> · <code>W3C autoplay-policy §3.2.2 compliant</code> · <code>iOS parity verified</code> · <code>AES-256-GCM session crypto</code> · <code>per-request CSP nonces</code>
+  <code>29/29 tests</code> · <code>RTL + jsdom component tests</code> · <code>0 lint warnings</code> · <code>W3C autoplay-policy §3.2.2 compliant</code> · <code>iOS parity verified</code> · <code>AES-256-GCM session crypto</code> · <code>per-request CSP nonces</code>
 </p>
 
 <p align="center">
@@ -52,7 +52,7 @@ Most chat starters are 200 lines of "fetch → render." This one is closer to a 
 - A **three-layer audio experience** — royalty-free stadium crowd kicks in on your first tap; the licensed Pond5 *Aerophonia* track fades in after the welcome message types out; a one-shot `crowd-booing.mp3` lands over the crowd when a key fails validation, in sync with the pulse-red error
 - A **W3C autoplay-policy §3.2.2-compliant** `AudioContext` unlock — synchronous construction + resume inside the gesture frame, so Chrome's reporter accepts it without warning
 - A **cyan → violet → fuchsia** palette wrapped in `@theme` tokens, doodle hearts flanking the subtitle, a `prism-line` accent under the headline
-- Eight **focused hooks** that own all behavior, one per concern (`useChatPersistence`, `useChatStreaming`, `useKeyLifecycle`, `useChatScroll`, `useShellBurstFlash`, `useWelcomeInjection`, `useSoundExperience`, `useAmbientConfetti`)
+- Nine **focused hooks** that own all behavior, one per concern (`useChatPersistence`, `useChatStreaming`, `useKeyLifecycle`, `useChatScroll`, `useShellBurstFlash`, `useWelcomeInjection`, `useSoundExperience`, `useAmbientConfetti`, `useModelPreference`)
 - A **single zod source of truth** for runtime validation at every trust boundary
 - A security posture you could put in front of a code review: AES-256-GCM-sealed cookies, strict CSP with per-request nonces, sliding-window rate limit, same-origin guard, SSRF defense on the audio proxy, the full HTTP-header set
 
@@ -83,7 +83,7 @@ Formatting rules (always follow these):
 |---|---|
 | Framework | **Next.js 16** (App Router) on Node runtime |
 | Styling | **Tailwind v4** with `@theme` palette tokens + glass primitives in `globals.css` |
-| Components | **shadcn/ui** primitives + custom `MovingBorder` for the animated shell perimeter |
+| Components | **shadcn/ui** primitives — `Button`, `Card`, `Input`, `Label`, `Textarea`, `Select` (Radix), `Tooltip` (Radix) — + custom `MovingBorder` for the animated shell perimeter |
 | Markdown | **react-markdown** + **remark-gfm** for assistant message rendering |
 | Validation | **zod** at every trust boundary |
 | Lint / format | **biome v2** (one tool, runs in milliseconds, **0 warnings on `main`**) |
@@ -323,6 +323,38 @@ The **`bufferCache` Map** ([`lib/audio/audio-orchestrator.ts`](lib/audio/audio-o
 
 **`unlockAudioContextSync()`** is the W3C-compliant entry point. The window-level gesture listener AND the LockedKeyCard `onBeforeSubmit` both call it BEFORE the async `startCrowd()`. Construction and `resume()` land on the synchronous call stack of the gesture handler, satisfying Chrome's autoplay-policy reporter. The async pipeline (`loadBuffer` → `BufferSource` → `start()`) follows, by which time the context is already running.
 
+Every silent failure path in [`lib/audio/audio-orchestrator.ts`](lib/audio/audio-orchestrator.ts) (`startCrowd`, `playBoo`, `startMusic`, `resume`) now emits a `console.warn("[audio] <op> failed:", error)` before returning, so audio failures are debuggable in DevTools instead of resolving to opaque silence. The runtime contract is unchanged — failures still resolve to silence rather than crashing the chat — but the failure mode is observable.
+
+---
+
+## Model selector
+
+A persistent in-app model preference for the chat — three tiers, one zod-validated source of truth.
+
+| Tier | Model ID | maxCompletionTokens | Use case |
+|---|---|---|---|
+| **Fast** (default) | `gpt-5-mini` | 4000 | Quick responses for everyday tasks |
+| Balanced | `gpt-5` | 4000 | Best mix of speed, intelligence, and accuracy |
+| Advanced | `gpt-5.5` | 4000 | Strongest reasoning for coding, research, and complex tasks |
+
+**Single source of truth:** [`lib/constants.ts`](lib/constants.ts) — adding or removing a model is a one-place change. The zod allowlist in [`lib/schemas.ts`](lib/schemas.ts), the dropdown UI, and the per-model token cap on `/api/chat` all derive from this `MODELS` array.
+
+**Persistence (UI preference, not conversation data):** [`lib/hooks/use-model-preference.ts`](lib/hooks/use-model-preference.ts) stores the selected model in `localStorage` under `coldplay_model_preference_v1`. Three semantic storage tiers in this app, three different stores — credentials in an AES-256-GCM-sealed httpOnly cookie, conversation in sessionStorage (wiped on Disconnect), UI preference in localStorage (survives Disconnect). Defensive on hydrate: a tampered localStorage value fails `isModelId()` and falls back to `DEFAULT_MODEL` rather than poisoning the dropdown.
+
+**Server-side validation:** `/api/chat` validates the optional `model` field through `modelIdSchema` (zod enum derived from `MODELS`). An invalid model returns `400 Bad Request` at the same boundary that catches malformed `message` payloads. The route resolves the per-model token cap and applies `min(modelCap, OPENAI_MAX_COMPLETION_TOKENS)` so an operator can still cap globally via env override — per-model wins for runtime requests, env wins as a ceiling.
+
+**Retry semantics:** [`useChatStreaming`](lib/hooks/use-chat-streaming.ts) captures the `(message, model)` pair on every submission so Retry replays the exact original payload, even if the user has since changed their dropdown selection.
+
+**UI:** the selector trigger sits at the left of the composer-tools bar and is itself wrapped in a shadcn `Tooltip` so hovering surfaces the current model's name, id, and description without forcing a click.
+
+---
+
+## Tooltip system
+
+Every interactive control that warrants a hint is wrapped in a shadcn `Tooltip` (Radix-backed, glass-styled): the model selector trigger, SoundToggle, Sparkles prompt randomizer, Send, Stop, Disconnect, and Verify Key. Native `title=` attributes — which are inconsistent across browsers and a no-op on touch devices — were replaced with the accessible, keyboard-focusable, mobile-friendly equivalent. A single root `<TooltipProvider delayDuration={250}>` in [`app/layout.tsx`](app/layout.tsx) covers the whole tree.
+
+Self-explanatory text buttons (Retry, Dismiss, example prompts) and descriptive non-interactive copy (speaker pill, feedback line, status text) are intentionally left without tooltips — adding them there would be noise.
+
 ---
 
 ## Deploy to Vercel
@@ -354,12 +386,18 @@ Region pin (`iad1`) and per-function memory / duration live in [`vercel.json`](v
 ## Tests
 
 ```bash
-pnpm test:run                  # vitest, single-pass — currently 22/22 green
+pnpm test:run                  # vitest, single-pass — currently 29/29 green
 pnpm test                      # vitest, watch mode
 pnpm test:e2e                  # playwright on port 3010 against a prod build
 ```
 
 The e2e tests build into `.next-test/` (separate from your `.next/`) and run on port **3010**, so you can keep `pnpm dev` on 3000 while tests execute. `tests/global-setup.ts` pins a `TEST_SESSION_SECRET` so boot-time env validation passes without reusing your real production secret.
+
+### Component-test infrastructure
+
+Default vitest environment is `node` for fast server-side tests (route handlers, server actions, pure libs). **Component tests opt in to `jsdom`** via a `// @vitest-environment jsdom` pragma at file top — each test file picks the right environment without a separate config or runner. Render helpers wrap with `<TooltipProvider>` to mirror the real root layout. Stack: `@testing-library/react` + `@testing-library/jest-dom` + `jsdom`.
+
+Example: [`tests/connection-status-card.test.tsx`](tests/connection-status-card.test.tsx) covers the status-dot color contract as a 4-case truth table (locked / error / both / verified-healthy). Same pattern unblocks every future component test.
 
 Two opt-in visual configs:
 
@@ -442,25 +480,26 @@ frontend/
 │   ├── not-found.tsx           # custom brand-voice 404 page (same gradient + epigraphs)
 │   └── page.tsx                # server-side unseal + initial verified state
 ├── components/
-│   ├── chat/                   # the decomposed chat surface (shell, panel, composer, locked card, messages…)
+│   ├── chat/                   # the decomposed chat surface (shell, panel, composer, locked card, messages, model-selector…)
 │   ├── decoration/             # aurora, doodle hearts, crowd silhouette, "Love is the only answer"
 │   ├── layout/                 # hero, disclaimer footer, layout-root
 │   ├── sound/                  # speaker toggle pill
-│   └── ui/                     # shadcn primitives + moving-border
+│   └── ui/                     # shadcn primitives — button, card, input, label, textarea, select, tooltip, moving-border
 ├── lib/
 │   ├── audio/
 │   │   ├── audio-orchestrator.ts  # 3-layer orchestrator + unlockAudioContextSync + bufferCache
 │   │   └── tracks.ts              # SOUND_TRACKS config (crowd, music, boo)
-│   ├── chat-client.ts          # client-side streamChatMessage helper (calls /api/chat)
+│   ├── chat-client.ts          # client-side streamChatMessage helper (calls /api/chat) — forwards model
 │   ├── chat-state.ts           # message-array reducers (completeAssistantAnimation, etc.)
-│   ├── chat-types.ts           # ChatMessage type re-exports from schemas
+│   ├── chat-types.ts           # ChatMessage + ModelId type re-exports from schemas + constants
 │   ├── confetti.ts             # fireOnUserAction wrapper around canvas-confetti
+│   ├── constants.ts            # MODELS array — single source of truth for the model dropdown allowlist + per-model token caps
 │   ├── csrf.ts                 # isSameOrigin guard (lifted from inline)
 │   ├── data/auth.ts            # DAL: verifyAndStoreKey, getVerifiedKey, clearVerifiedKey
 │   ├── env.ts                  # boot-time env validation + SESSION_SECRET strength gate
-│   ├── hooks/                  # the eight feature hooks
+│   ├── hooks/                  # the nine feature hooks (incl. useModelPreference for the new dropdown)
 │   ├── rate-limit.ts           # Upstash + in-memory adapter (sliding window)
-│   ├── schemas.ts              # zod single source of truth
+│   ├── schemas.ts              # zod single source of truth (incl. modelIdSchema derived from MODELS)
 │   ├── session-crypto.ts       # AES-256-GCM seal/unseal
 │   └── utils.ts                # cn helper (clsx + tailwind-merge)
 ├── docs/


### PR DESCRIPTION
## Summary

Both READMEs were trailing the five submission-day PRs that shipped after the last docs refresh (#51). Brings the user-facing narrative back in sync with main.

## Root README — Adjustments Made table

- Intro: *"Five PRs shipped"* → *"Nine PRs shipped"*
- Added rows for:
  - **#53** locked-status-dot fix + RTL component-test infra
  - **#54** shadcn Tooltip system
  - **#55** model selector with persistent preference + per-model token caps
  - **#56** audio-orchestrator \`console.warn\` sweep + HeartDoodle reposition
- Results: \`22/22 tests\` → **\`29/29 tests\`** (+4 component truth-table cases, +3 chat-route model-validation cases)
- New **a11y posture** bullet noting the Tooltip + component-test coverage gain

## Frontend README

| Edit | Before | After |
|---|---|---|
| Stats badge | \`22/22 tests\` | \`29/29 tests · RTL + jsdom component tests\` |
| Hooks line | *"Eight focused hooks"* | *"Nine focused hooks"* (+ \`useModelPreference\`) |
| Stack row | "shadcn/ui primitives + MovingBorder" | explicit primitive list incl. \`Select\` (Radix) + \`Tooltip\` (Radix) |
| Audio architecture | — | new paragraph documenting the \`console.warn\` observability sweep across all 4 silent catches |
| **NEW section** | — | **Model selector** — three-tier table, single-source-of-truth via \`lib/constants.ts\`, localStorage rationale (UI preference != conversation data; survives Disconnect), zod allowlist + per-model cap, retry semantics, Tooltip-wrapped trigger |
| **NEW section** | — | **Tooltip system** — comprehensive coverage + which controls are intentionally NOT wrapped (text buttons + descriptive copy) |
| **NEW subsection** | — | **Component-test infrastructure** in Tests section — \`@vitest-environment jsdom\` pragma pattern, RTL + jest-dom stack, \`<TooltipProvider>\` render-helper pattern |
| File map | — | + \`lib/constants.ts\`, \`lib/hooks/use-model-preference.ts\`, \`components/chat/model-selector.tsx\`, \`components/ui/select.tsx\`, \`components/ui/tooltip.tsx\` with inline annotations; "eight feature hooks" → "nine feature hooks" |

## Gates

- 2 files changed, **+57 / -13**
- typecheck / biome / **29/29 tests** / production build all clean

## Test plan

- [ ] Render the root README on GitHub → Adjustments Made table shows all 9 PRs
- [ ] Render the frontend README on GitHub → Model Selector + Tooltip + Component-test sections present; file map reflects new files
- [ ] No code regressions (gates green, no source files touched)