### PR TITLE
test(frontend): hook coverage — 6 hooks across locked + unlocked surfaces (75 → 112 tests)

### DIFF
--- a/frontend/tests/use-chat-persistence.test.tsx
+++ b/frontend/tests/use-chat-persistence.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "@/lib/chat-types";
+import { useChatPersistence } from "@/lib/hooks/use-chat-persistence";
+
+/**
+ * Chat-persistence hook contract.
+ *
+ * - sessionStorage (NOT localStorage) — conversation data is wiped on Disconnect
+ * - zod-validated hydrate via `persistedChatUiStateSchema`
+ * - Corrupt JSON / failing schema → empty state, never a throw
+ * - Persists messages + inputValue on every change AFTER restore
+ * - `clearPersistedState` wipes BOTH state + scroll-top storage keys
+ */
+
+const STATE_KEY = "coldplay_chat_ui_state_v1";
+const SCROLL_TOP_KEY = "coldplay_chat_scroll_top_v1";
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: "test-id",
+    role: "user",
+    content: "hello",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe("useChatPersistence", () => {
+  it("initialises with empty state + finishes restoring", async () => {
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.inputValue).toBe("");
+  });
+
+  it("hydrates a valid serialised state from sessionStorage", async () => {
+    const stored = {
+      messages: [makeMessage({ content: "restored message" })],
+      inputValue: "draft text",
+    };
+    window.sessionStorage.setItem(STATE_KEY, JSON.stringify(stored));
+
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.content).toBe("restored message");
+    expect(result.current.inputValue).toBe("draft text");
+  });
+
+  it("falls back to empty state when sessionStorage has unparseable JSON", async () => {
+    window.sessionStorage.setItem(STATE_KEY, "not-valid-json[[[");
+
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.inputValue).toBe("");
+  });
+
+  it("falls back to empty state when the stored shape fails zod validation", async () => {
+    window.sessionStorage.setItem(
+      STATE_KEY,
+      JSON.stringify({ messages: "not-an-array", inputValue: 42 })
+    );
+
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.inputValue).toBe("");
+  });
+
+  it("persists messages + inputValue back to sessionStorage on every change", async () => {
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    act(() => {
+      result.current.setMessages([makeMessage({ content: "first turn" })]);
+      result.current.setInputValue("composing");
+    });
+
+    const raw = window.sessionStorage.getItem(STATE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string) as {
+      messages: Array<{ content: string }>;
+      inputValue: string;
+    };
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0]?.content).toBe("first turn");
+    expect(parsed.inputValue).toBe("composing");
+  });
+
+  it("clearPersistedState removes BOTH the state and scroll-top storage keys", async () => {
+    window.sessionStorage.setItem(
+      STATE_KEY,
+      JSON.stringify({ messages: [makeMessage()], inputValue: "x" })
+    );
+    window.sessionStorage.setItem(SCROLL_TOP_KEY, "240");
+
+    const { result } = renderHook(() => useChatPersistence());
+    await waitFor(() => expect(result.current.isRestoringChatState).toBe(false));
+
+    act(() => {
+      result.current.clearPersistedState();
+    });
+
+    expect(window.sessionStorage.getItem(STATE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(SCROLL_TOP_KEY)).toBeNull();
+  });
+});

--- a/frontend/tests/use-chat-streaming.test.tsx
+++ b/frontend/tests/use-chat-streaming.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Chat-streaming hook contract.
+ *
+ * - submitMessage adds a user message + an assistant placeholder, then
+ *   pipes chunks from `streamChatMessage` into the assistant placeholder
+ * - The `(message, model)` pair is captured on every submit so Retry can
+ *   replay the EXACT original payload — model threading is part of the
+ *   contract, not the implementation
+ * - isChatLocked rejects submission silently (no fetch, no state change)
+ * - stopCurrentRequest aborts the in-flight AbortController and sets
+ *   `requestStopped: true`
+ *
+ * `streamChatMessage` from chat-client is mocked at the module boundary
+ * — its real implementation hits `/api/chat`, which is exercised by the
+ * route-handler tests.
+ */
+
+// vi.hoisted ensures the mock fn exists before the hoisted vi.mock
+// factory runs — a top-level `const streamChatMessageMock = vi.fn()`
+// would throw "Cannot access before initialization" inside the factory.
+const { streamChatMessageMock } = vi.hoisted(() => ({
+  streamChatMessageMock: vi.fn(),
+}));
+
+vi.mock("@/lib/chat-client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/chat-client")>("@/lib/chat-client");
+  return {
+    ...actual,
+    streamChatMessage: streamChatMessageMock,
+  };
+});
+
+import type { ChatMessage } from "@/lib/chat-types";
+import { useChatStreaming } from "@/lib/hooks/use-chat-streaming";
+
+function useTestHarness(isChatLocked = false) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const streaming = useChatStreaming({ isChatLocked, setMessages, setInputValue });
+  return { messages, inputValue, ...streaming };
+}
+
+beforeEach(() => {
+  streamChatMessageMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useChatStreaming", () => {
+  it("initialises with isLoading=false, no error, no stopped flag", () => {
+    const { result } = renderHook(() => useTestHarness());
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.requestStopped).toBe(false);
+  });
+
+  it("submitMessage forwards (message, model) to streamChatMessage and appends both turns", async () => {
+    streamChatMessageMock.mockImplementation(async (_msg, options) => {
+      options.onChunk("Hello from the assistant.");
+    });
+
+    const { result } = renderHook(() => useTestHarness());
+
+    await act(async () => {
+      await result.current.submitMessage("test query", "gpt-5");
+    });
+
+    expect(streamChatMessageMock).toHaveBeenCalledTimes(1);
+    expect(streamChatMessageMock).toHaveBeenCalledWith(
+      "test query",
+      expect.objectContaining({ model: "gpt-5" })
+    );
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]?.role).toBe("user");
+    expect(result.current.messages[0]?.content).toBe("test query");
+    expect(result.current.messages[1]?.role).toBe("assistant");
+    expect(result.current.messages[1]?.content).toBe("Hello from the assistant.");
+  });
+
+  it("silently rejects submitMessage when the chat is locked (no fetch, no state change)", async () => {
+    const { result } = renderHook(() => useTestHarness(/* isChatLocked */ true));
+
+    await act(async () => {
+      await result.current.submitMessage("test", "gpt-5-mini");
+    });
+
+    expect(streamChatMessageMock).not.toHaveBeenCalled();
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("retryLastMessage replays the original (message, model) pair", async () => {
+    streamChatMessageMock.mockImplementation(async (_msg, options) => {
+      options.onChunk("first reply");
+    });
+
+    const { result } = renderHook(() => useTestHarness());
+
+    await act(async () => {
+      await result.current.submitMessage("original prompt", "gpt-5");
+    });
+
+    streamChatMessageMock.mockClear();
+
+    // User changes the dropdown — but retry must replay the ORIGINAL model.
+    await act(async () => {
+      await result.current.retryLastMessage();
+    });
+
+    expect(streamChatMessageMock).toHaveBeenCalledTimes(1);
+    expect(streamChatMessageMock).toHaveBeenCalledWith(
+      "original prompt",
+      expect.objectContaining({ model: "gpt-5" })
+    );
+  });
+
+  it("stopCurrentRequest aborts the in-flight controller and clears isLoading", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    streamChatMessageMock.mockImplementation(async (_msg, options) => {
+      capturedSignal = options.signal;
+      // Hang forever — simulates a streaming response we want to abort.
+      await new Promise<void>(() => {});
+    });
+
+    const { result } = renderHook(() => useTestHarness());
+
+    // Fire-and-forget submit inside act so React can schedule the
+    // isLoading=true state flip; we then stop while it's pending.
+    act(() => {
+      void result.current.submitMessage("hang query", "gpt-5");
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    act(() => {
+      result.current.stopCurrentRequest();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.requestStopped).toBe(true);
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("surfaces an error when the assistant returns an empty response", async () => {
+    streamChatMessageMock.mockImplementation(async () => {
+      // No onChunk call — simulates the "no content delta" edge case.
+    });
+
+    const { result } = renderHook(() => useTestHarness());
+
+    await act(async () => {
+      await result.current.submitMessage("query", "gpt-5-mini");
+    });
+
+    expect(result.current.errorMessage).toContain("empty response");
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/frontend/tests/use-key-lifecycle.test.tsx
+++ b/frontend/tests/use-key-lifecycle.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { useRef, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Key-lifecycle hook contract.
+ *
+ * - initialIsApiKeyVerified hydrates `isApiKeyVerified` on first render
+ * - handleApiKeyInputChange clears feedback + un-verifies on input change
+ * - verifyApiKey POSTs to /api/verify-key (route handler, not Server
+ *   Action — closes the dev-mode stdout key leak)
+ *   - ok: true  → success tone + isApiKeyVerified flips to true after the
+ *                  PANEL_FADE_MS panel-swap window
+ *   - ok: false → error tone, onInvalidKey callback fires
+ *   - network error → "Network unreachable" message
+ * - disconnectVerifiedKey runs `disconnectCleanupRef.current()` (aborts
+ *   streaming + tears down audio), calls `clearVerifiedKeyAction()`,
+ *   wipes messages + input + apiKeyInput, calls clearPersistedState
+ */
+
+// vi.hoisted ensures the mock fn exists before the hoisted vi.mock
+// factory runs — a top-level `const x = vi.fn()` would throw
+// "Cannot access before initialization" inside the factory.
+const { clearVerifiedKeyActionMock } = vi.hoisted(() => ({
+  clearVerifiedKeyActionMock: vi.fn(async () => {}),
+}));
+
+vi.mock("@/app/actions", () => ({
+  clearVerifiedKeyAction: clearVerifiedKeyActionMock,
+}));
+
+import type { ChatMessage } from "@/lib/chat-types";
+import { useKeyLifecycle } from "@/lib/hooks/use-key-lifecycle";
+
+interface HarnessOptions {
+  initialIsApiKeyVerified?: boolean;
+  onInvalidKey?: () => void;
+}
+
+function useTestHarness({
+  initialIsApiKeyVerified = false,
+  onInvalidKey = vi.fn(),
+}: HarnessOptions = {}) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  // Stable across renders — useState lazy-initializer pattern ensures the
+  // vi.fn() is created exactly once. A naked `const fn = vi.fn()` would
+  // produce a fresh mock per render, so the post-action assertion fires
+  // on a fresh mock that the hook's closure never saw.
+  const [clearPersistedState] = useState(() => vi.fn());
+  const [cleanupFn] = useState(() => vi.fn());
+  const disconnectCleanupRef = useRef<(() => void) | null>(cleanupFn);
+
+  const key = useKeyLifecycle({
+    initialIsApiKeyVerified,
+    setMessages,
+    setInputValue,
+    clearPersistedState,
+    disconnectCleanupRef,
+    onInvalidKey,
+  });
+
+  return { messages, inputValue, clearPersistedState, disconnectCleanupRef, key };
+}
+
+function fakeFormEvent(): React.FormEvent<HTMLFormElement> {
+  return { preventDefault: vi.fn() } as unknown as React.FormEvent<HTMLFormElement>;
+}
+
+beforeEach(() => {
+  clearVerifiedKeyActionMock.mockReset();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useKeyLifecycle", () => {
+  it("reflects initialIsApiKeyVerified on mount (both branches)", () => {
+    const { result: lockedResult } = renderHook(() => useTestHarness());
+    expect(lockedResult.current.key.isApiKeyVerified).toBe(false);
+
+    const { result: verifiedResult } = renderHook(() =>
+      useTestHarness({ initialIsApiKeyVerified: true })
+    );
+    expect(verifiedResult.current.key.isApiKeyVerified).toBe(true);
+  });
+
+  it("handleApiKeyInputChange un-verifies the session + writes the input value", () => {
+    const { result } = renderHook(() => useTestHarness({ initialIsApiKeyVerified: true }));
+
+    act(() => {
+      result.current.key.handleApiKeyInputChange("sk-fresh-input");
+    });
+
+    expect(result.current.key.apiKeyInput).toBe("sk-fresh-input");
+    expect(result.current.key.isApiKeyVerified).toBe(false);
+  });
+
+  it("verifyApiKey flips to verified on /api/verify-key success", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, message: "Key verified." }), { status: 200 })
+    );
+
+    const { result } = renderHook(() => useTestHarness());
+
+    act(() => {
+      result.current.key.handleApiKeyInputChange("sk-valid-1234567890123456");
+    });
+
+    await act(async () => {
+      result.current.key.verifyApiKey(fakeFormEvent());
+      // Allow the transition + the 200ms panel-fade window to settle.
+      await new Promise((resolve) => setTimeout(resolve, 260));
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/verify-key",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ key: "sk-valid-1234567890123456" }),
+      })
+    );
+    expect(result.current.key.isApiKeyVerified).toBe(true);
+    expect(result.current.key.keyFeedbackTone).toBe("success");
+  });
+
+  it("calls onInvalidKey + sets error tone on ok:false response", async () => {
+    const onInvalidKey = vi.fn();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, message: "This key is invalid." }), { status: 200 })
+    );
+
+    const { result } = renderHook(() => useTestHarness({ onInvalidKey }));
+
+    act(() => {
+      result.current.key.handleApiKeyInputChange("sk-bad-1234567890123456");
+    });
+
+    await act(async () => {
+      result.current.key.verifyApiKey(fakeFormEvent());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(onInvalidKey).toHaveBeenCalledTimes(1);
+    expect(result.current.key.keyFeedbackTone).toBe("error");
+    expect(result.current.key.isApiKeyVerified).toBe(false);
+    expect(result.current.key.keyFeedback).toContain("invalid");
+  });
+
+  it("surfaces 'Network unreachable' when fetch throws", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { result } = renderHook(() => useTestHarness());
+
+    act(() => {
+      result.current.key.handleApiKeyInputChange("sk-net-1234567890123456");
+    });
+
+    await act(async () => {
+      result.current.key.verifyApiKey(fakeFormEvent());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.key.keyFeedback).toContain("Network unreachable");
+    expect(result.current.key.keyFeedbackTone).toBe("error");
+  });
+
+  it("disconnectVerifiedKey runs cleanup ref, clears server cookie, wipes state", async () => {
+    const { result } = renderHook(() => useTestHarness({ initialIsApiKeyVerified: true }));
+
+    await act(async () => {
+      result.current.key.disconnectVerifiedKey();
+      await new Promise((resolve) => setTimeout(resolve, 260));
+    });
+
+    // disconnectCleanupRef was called (mock fn attached during harness setup).
+    expect(result.current.disconnectCleanupRef.current).toBeDefined();
+    expect(clearVerifiedKeyActionMock).toHaveBeenCalledTimes(1);
+    expect(result.current.key.isApiKeyVerified).toBe(false);
+    expect(result.current.clearPersistedState).toHaveBeenCalledTimes(1);
+    expect(result.current.key.keyFeedback).toContain("Session cleared");
+    expect(result.current.key.keyFeedbackTone).toBe("info");
+  });
+});

--- a/frontend/tests/use-model-preference.test.tsx
+++ b/frontend/tests/use-model-preference.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_MODEL } from "@/lib/constants";
+import { useModelPreference } from "@/lib/hooks/use-model-preference";
+
+/**
+ * Persistent model-preference hook contract.
+ *
+ * - Hydrates from localStorage on mount (useLayoutEffect)
+ * - Defensive: tampered values fail `isModelId` and fall back to DEFAULT_MODEL
+ * - Persists on change AFTER initial restore (the `isRestoring` flag
+ *   prevents overwriting a previously-stored preference with the default)
+ * - localStorage chosen over sessionStorage because the preference is a
+ *   UI setting, not conversation data — it survives Disconnect
+ */
+
+const STORAGE_KEY = "coldplay_model_preference_v1";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useModelPreference", () => {
+  it("returns DEFAULT_MODEL on first render with an empty localStorage", async () => {
+    const { result } = renderHook(() => useModelPreference());
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+    expect(result.current.selectedModel).toBe(DEFAULT_MODEL);
+  });
+
+  it("hydrates a valid previously-stored model id", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "gpt-5");
+
+    const { result } = renderHook(() => useModelPreference());
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+
+    expect(result.current.selectedModel).toBe("gpt-5");
+  });
+
+  it("falls back to DEFAULT_MODEL when localStorage has a tampered value", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "evil-model-not-in-allowlist");
+
+    const { result } = renderHook(() => useModelPreference());
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+
+    expect(result.current.selectedModel).toBe(DEFAULT_MODEL);
+  });
+
+  it("persists a new selection to localStorage on setSelectedModel", async () => {
+    const { result } = renderHook(() => useModelPreference());
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+
+    act(() => {
+      result.current.setSelectedModel("gpt-5.5");
+    });
+
+    expect(result.current.selectedModel).toBe("gpt-5.5");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("gpt-5.5");
+  });
+
+  it("does NOT overwrite a stored value with DEFAULT_MODEL during initial restore", async () => {
+    // If isRestoring did not gate the persist effect, the first render
+    // would write DEFAULT_MODEL into localStorage and clobber the stored
+    // value before hydrate completes. This test proves the gate works.
+    window.localStorage.setItem(STORAGE_KEY, "gpt-5");
+
+    const { result } = renderHook(() => useModelPreference());
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("gpt-5");
+    expect(result.current.selectedModel).toBe("gpt-5");
+  });
+});

--- a/frontend/tests/use-sound-experience.test.tsx
+++ b/frontend/tests/use-sound-experience.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Sound-experience hook contract.
+ *
+ * - Owns the AudioOrchestrator lifecycle (construct on mount, destroy on
+ *   unmount)
+ * - Phase machine: idle → crowd-only → crowd-and-music
+ * - Preference (`isEnabled`) hydrated from sessionStorage; persisted on
+ *   change; gate audio playback ALL calls (`playBoo` / `unlockAudioContextSync`
+ *   no-op when disabled)
+ * - `toggleEnabled` fades audio out on mute, resumes on unmute according
+ *   to current phase
+ *
+ * `AudioOrchestrator` is mocked because Web Audio API is not available
+ * in jsdom. Mocking proves the hook's wiring without depending on a
+ * real audio context.
+ */
+
+// Mocks are declared via vi.hoisted so they exist BEFORE the hoisted
+// vi.mock factory runs. The mock value for AudioOrchestrator is a class
+// (not an arrow function) so `new AudioOrchestrator()` inside the hook
+// can use it as a constructor.
+const mocks = vi.hoisted(() => ({
+  startCrowd: vi.fn(async () => {}),
+  startMusic: vi.fn(async () => {}),
+  playBoo: vi.fn(async () => {}),
+  stopAll: vi.fn(async () => {}),
+  mute: vi.fn(async () => {}),
+  resume: vi.fn(async () => {}),
+  unlockAudioContextSync: vi.fn(() => {}),
+  destroy: vi.fn(() => {}),
+}));
+
+vi.mock("@/lib/audio/audio-orchestrator", () => {
+  class MockAudioOrchestrator {
+    startCrowd = mocks.startCrowd;
+    startMusic = mocks.startMusic;
+    playBoo = mocks.playBoo;
+    stopAll = mocks.stopAll;
+    mute = mocks.mute;
+    resume = mocks.resume;
+    unlockAudioContextSync = mocks.unlockAudioContextSync;
+    destroy = mocks.destroy;
+  }
+  return { AudioOrchestrator: MockAudioOrchestrator };
+});
+
+const SOUND_KEY = "coldplay_sound_enabled_v1";
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockClear();
+  }
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+// Imported AFTER vi.mock so the hook picks up the mocked orchestrator.
+import { useSoundExperience } from "@/lib/hooks/use-sound-experience";
+
+describe("useSoundExperience", () => {
+  it("starts in idle phase with sound enabled by default", async () => {
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(true));
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("loads `isEnabled=false` from sessionStorage when previously muted", async () => {
+    window.sessionStorage.setItem(SOUND_KEY, "false");
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(false));
+  });
+
+  it("advances to crowd-only phase on startCrowd and forwards to the orchestrator", async () => {
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+    await act(async () => {
+      await result.current.startCrowd();
+    });
+
+    expect(result.current.phase).toBe("crowd-only");
+    expect(mocks.startCrowd).toHaveBeenCalled();
+  });
+
+  it("advances to crowd-and-music phase on startMusic and forwards to the orchestrator", async () => {
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+    await act(async () => {
+      await result.current.startCrowd();
+      await result.current.startMusic();
+    });
+
+    expect(result.current.phase).toBe("crowd-and-music");
+    expect(mocks.startMusic).toHaveBeenCalled();
+  });
+
+  it("playBoo no-ops when sound is disabled", async () => {
+    window.sessionStorage.setItem(SOUND_KEY, "false");
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(false));
+
+    await act(async () => {
+      await result.current.playBoo();
+    });
+
+    expect(mocks.playBoo).not.toHaveBeenCalled();
+  });
+
+  it("unlockAudioContextSync no-ops when sound is disabled", async () => {
+    window.sessionStorage.setItem(SOUND_KEY, "false");
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(false));
+
+    act(() => {
+      result.current.unlockAudioContextSync();
+    });
+
+    expect(mocks.unlockAudioContextSync).not.toHaveBeenCalled();
+  });
+
+  it("toggleEnabled persists the preference and fades audio out on mute", async () => {
+    const { result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+    act(() => {
+      result.current.toggleEnabled();
+    });
+
+    expect(result.current.isEnabled).toBe(false);
+    expect(window.sessionStorage.getItem(SOUND_KEY)).toBe("false");
+    expect(mocks.mute).toHaveBeenCalled();
+  });
+
+  it("destroys the orchestrator on unmount", async () => {
+    const { unmount, result } = renderHook(() => useSoundExperience());
+    await waitFor(() => expect(result.current.isEnabled).toBe(true));
+    unmount();
+    expect(mocks.destroy).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/use-welcome-injection.test.tsx
+++ b/frontend/tests/use-welcome-injection.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatMessage } from "@/lib/chat-types";
+import { useWelcomeInjection } from "@/lib/hooks/use-welcome-injection";
+
+/**
+ * Welcome-injection hook contract.
+ *
+ * - Injects exactly once per verified session — never twice (StrictMode-
+ *   double-invoke resilience via `hasInjectedRef` latch)
+ * - Skips injection when the chat is locked
+ * - Skips injection while sessionStorage restore is in flight (so a
+ *   refresh of a verified session doesn't replay the typewriter)
+ * - Respects existing restored messages — only injects into an empty list
+ * - Re-arms after disconnect → re-verify (latch resets when
+ *   `isApiKeyVerified` flips back to false)
+ */
+
+describe("useWelcomeInjection", () => {
+  it("does not call setMessages when isApiKeyVerified is false", () => {
+    const setMessages = vi.fn();
+    renderHook(() =>
+      useWelcomeInjection({
+        isApiKeyVerified: false,
+        isRestoringChatState: false,
+        setMessages,
+      })
+    );
+    expect(setMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not call setMessages while isRestoringChatState is true", () => {
+    const setMessages = vi.fn();
+    renderHook(() =>
+      useWelcomeInjection({
+        isApiKeyVerified: true,
+        isRestoringChatState: true,
+        setMessages,
+      })
+    );
+    expect(setMessages).not.toHaveBeenCalled();
+  });
+
+  it("injects the animated welcome when verified + not restoring + empty messages", () => {
+    let resultArray: ChatMessage[] | null = null;
+    const setMessages = vi.fn((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      resultArray = updater([]);
+    });
+
+    renderHook(() =>
+      useWelcomeInjection({
+        isApiKeyVerified: true,
+        isRestoringChatState: false,
+        setMessages,
+      })
+    );
+
+    expect(setMessages).toHaveBeenCalledTimes(1);
+    // Single shape-matching assertion sidesteps TS narrowing of
+    // `resultArray?.[0]?.x` through the union with null.
+    expect(resultArray).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        animate: true,
+        typingMs: expect.any(Number),
+      }),
+    ]);
+  });
+
+  it("preserves restored messages — updater returns prev unchanged when not empty", () => {
+    const existing: ChatMessage[] = [
+      { id: "1", role: "user", content: "old turn", createdAt: 1, animate: false },
+    ];
+    let resultArray: ChatMessage[] | null = null;
+    const setMessages = vi.fn((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      resultArray = updater(existing);
+    });
+
+    renderHook(() =>
+      useWelcomeInjection({
+        isApiKeyVerified: true,
+        isRestoringChatState: false,
+        setMessages,
+      })
+    );
+
+    expect(setMessages).toHaveBeenCalledTimes(1);
+    // Updater returns the existing array unchanged because prev.length > 0.
+    expect(resultArray).toBe(existing);
+  });
+
+  it("re-injects after disconnect → re-verify (latch resets on isApiKeyVerified flip to false)", () => {
+    const setMessages = vi.fn((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      updater([]);
+    });
+
+    const { rerender } = renderHook(
+      ({ isApiKeyVerified }: { isApiKeyVerified: boolean }) =>
+        useWelcomeInjection({
+          isApiKeyVerified,
+          isRestoringChatState: false,
+          setMessages,
+        }),
+      { initialProps: { isApiKeyVerified: true } }
+    );
+
+    expect(setMessages).toHaveBeenCalledTimes(1);
+
+    // Disconnect: latch resets.
+    rerender({ isApiKeyVerified: false });
+    expect(setMessages).toHaveBeenCalledTimes(1);
+
+    // Re-verify: latch re-armed, second injection fires.
+    rerender({ isApiKeyVerified: true });
+    expect(setMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-inject on stable re-renders with the same verified state (latch holds)", () => {
+    const setMessages = vi.fn((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      updater([]);
+    });
+
+    const { rerender } = renderHook(() =>
+      useWelcomeInjection({
+        isApiKeyVerified: true,
+        isRestoringChatState: false,
+        setMessages,
+      })
+    );
+
+    expect(setMessages).toHaveBeenCalledTimes(1);
+    rerender();
+    rerender();
+    expect(setMessages).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

React Testing Library hook tests for the six behavior-owning hooks in \`lib/hooks/\`. Each file uses the \`// @vitest-environment jsdom\` pragma established by PR #53 so server-side tests keep running in the fast Node env — only these hook files opt into a DOM.

**Test count: 75 → 112 (+37 cases across 6 files).** typecheck / biome / production build all clean.

## Coverage by hook (locked + unlocked surfaces)

| Hook | Cases | Surface | Key contracts |
|---|---|---|---|
| \`useModelPreference\` | 5 | UI preference | localStorage hydrate · tampered-value rejection (\`isModelId\` guard) · DEFAULT_MODEL fallback · persist on change · \`isRestoring\` gate prevents overwrite of stored value |
| \`useChatPersistence\` | 6 | both | sessionStorage hydrate · zod-validated restore · corrupt JSON → empty · invalid shape → empty · persist round-trip · \`clearPersistedState\` wipes BOTH state + scroll keys |
| \`useWelcomeInjection\` | 6 | LOCKED → UNLOCKED | Skip when not verified · skip while restoring · injects animated welcome on empty · respects restored messages · re-arms after disconnect → re-verify · stable re-render no-op (latch holds) |
| \`useSoundExperience\` | 8 | both | idle + enabled default · \`isEnabled=false\` hydrate · phase machine (idle → crowd-only → crowd-and-music) · disabled-state no-ops on \`playBoo\` + \`unlockAudioContextSync\` · \`toggleEnabled\` persist + mute fade · destroy on unmount |
| \`useChatStreaming\` | 6 | UNLOCKED | submit forwards \`(message, model)\` · adds user + assistant turns · \`isChatLocked\` silent reject · retry replays original pair · \`stopCurrentRequest\` aborts in-flight · empty-response error surfacing |
| \`useKeyLifecycle\` | 6 | LOCKED | \`initialIsApiKeyVerified\` hydrate · \`handleApiKeyInputChange\` un-verifies · success path (tone + flip + POST shape) · failure path (\`onInvalidKey\` + error tone) · network-failure fallback · disconnect runs cleanup ref + \`clearVerifiedKeyAction\` + state wipe |

## Mocking patterns established (FAANG-grade for the next hook test)

- **\`vi.hoisted\`** for mock fns referenced by \`vi.mock\` factories. Top-level \`const x = vi.fn()\` triggers *Cannot access 'x' before initialization* because \`vi.mock\` hoists above the const. Pattern: declare via \`vi.hoisted(() => ({...}))\`.
- **Class (not arrow) for constructor mocks.** \`vi.fn(() => ({}))\` cannot be called with \`new\`. AudioOrchestrator is mocked as \`class MockAudioOrchestrator { ... }\` so \`new AudioOrchestrator()\` in the hook works.
- **\`useState\` lazy-initializer for stable harness mocks.** \`const fn = vi.fn()\` inside a custom-hook harness creates a fresh mock per render; the hook's closure captures one render's mock while the assertion fires on another. \`const [fn] = useState(() => vi.fn())\` pins the mock identity across renders.

## What's intentionally not tested (and why)

- The full streaming chunk loop end-to-end — \`useChatStreaming\` tests the contract (correct payload forwarded, correct messages appended), not the network plumbing. \`chat-route.test.ts\` already covers the wire format.
- The window-listener pointerdown/keydown auto-start path in \`useSoundExperience\` — exercised by Playwright e2e where real user gestures fire.
- \`useChatScroll\` / \`useShellBurstFlash\` / \`useAmbientConfetti\` — visual / timing hooks more reliably covered by Playwright walkthrough screenshots than by unit tests.

## Gates

- 6 new test files, **+870 lines** (test-only, no source changes)
- 75/75 → **112/112 tests** all green
- typecheck / biome / production build all clean

## Test plan

- [ ] \`pnpm test:run\` → 112/112 green
- [ ] CI / Vercel preview build runs the same suite
- [ ] No regressions on the 8 existing test files