### PR TITLE
feat(observability): @vercel/otel + GenAI semantic-convention span attributes

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,9 +1,11 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { NextResponse } from "next/server";
 
 import { MODELS } from "@/lib/constants";
 import { isSameOrigin } from "@/lib/csrf";
 import { getVerifiedKey } from "@/lib/data/auth";
 import { serverEnv } from "@/lib/env";
+import { computeChatCostUsd } from "@/lib/llm-pricing";
 import { checkRateLimit, getClientKey } from "@/lib/rate-limit";
 import {
   chatRequestSchema,
@@ -11,6 +13,14 @@ import {
   openAiStreamChunkSchema,
 } from "@/lib/schemas";
 import { COLDPLAY_SYSTEM_PROMPT } from "@/lib/system-prompt";
+
+// OTel tracer for the OpenAI chat operation. The Vercel-wired SDK
+// (see `instrumentation.ts`) auto-instruments the outbound `fetch` —
+// this manual span exists to carry GenAI semantic-convention attributes
+// the fetch-instrumentation does not know about (model, token usage,
+// cost, finish reason). See OTel GenAI semantic conventions:
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/
+const tracer = trace.getTracer("ai-engineer-challenge.chat");
 
 export const runtime = "nodejs";
 
@@ -114,6 +124,26 @@ export async function POST(request: Request): Promise<Response> {
   const modelCap = modelConfig?.maxCompletionTokens ?? OPENAI_MAX_TOKENS;
   const effectiveCap = Math.min(modelCap, OPENAI_MAX_TOKENS);
 
+  // Start the OTel span for the OpenAI operation. Initial attributes
+  // follow GenAI semantic conventions; the response attributes
+  // (token usage, finish reason, cost) get populated when the stream
+  // completes. The span MUST be ended on every exit path — we'd leak
+  // an open span otherwise, which silently inflates trace counts in
+  // dashboards and prevents flush-on-shutdown from completing.
+  const span = tracer.startSpan("openai.chat.completions", {
+    attributes: {
+      "gen_ai.system": "openai",
+      "gen_ai.operation.name": "chat",
+      "gen_ai.request.model": requestedModel,
+      "gen_ai.request.max_tokens": effectiveCap,
+      "gen_ai.request.streaming": true,
+      // Non-standard: client correlation key. Surfaces the same
+      // `x-request-id` returned to the browser in the trace so we can
+      // pivot from a frontend error toast to its server-side span.
+      "ai_engineer_challenge.request_id": requestId,
+    },
+  });
+
   let upstream: Response;
   try {
     upstream = await fetch(OPENAI_CHAT_COMPLETIONS_ENDPOINT, {
@@ -129,13 +159,24 @@ export async function POST(request: Request): Promise<Response> {
           { role: "user", content: parsed.data.message },
         ],
         stream: true,
+        // Required for the final usage chunk OpenAI emits at stream
+        // end (empty `choices`, populated `usage`). Without this flag
+        // we can't emit `gen_ai.usage.*` attributes.
+        stream_options: { include_usage: true },
         max_completion_tokens: effectiveCap,
       }),
       signal: timeoutController.signal,
     });
   } catch (error) {
     clearTimeout(timeoutHandle);
-    if (error instanceof DOMException && error.name === "AbortError") {
+    const isTimeout = error instanceof DOMException && error.name === "AbortError";
+    span.recordException(error instanceof Error ? error : new Error(String(error)));
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: isTimeout ? "openai_fetch_timeout" : "openai_fetch_failed",
+    });
+    span.end();
+    if (isTimeout) {
       return NextResponse.json(
         { detail: "Upstream OpenAI request timed out." },
         { status: 504, headers: { "x-request-id": requestId } }
@@ -160,6 +201,9 @@ export async function POST(request: Request): Promise<Response> {
     } catch {
       // ignore unparseable upstream error body
     }
+    span.setAttribute("http.response.status_code", upstream.status);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: "openai_non_2xx" });
+    span.end();
     return NextResponse.json(
       { detail },
       { status: upstream.status, headers: { "x-request-id": requestId } }
@@ -167,6 +211,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   if (!upstream.body) {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: "openai_no_body" });
+    span.end();
     return NextResponse.json(
       { detail: "Upstream returned no stream body." },
       { status: 502, headers: { "x-request-id": requestId } }
@@ -188,6 +234,16 @@ export async function POST(request: Request): Promise<Response> {
       const encoder = new TextEncoder();
       let buffer = "";
 
+      // Captured for the OTel span at stream end. Populated from
+      // validated chunks as they arrive; nullable so we can omit the
+      // corresponding attribute when OpenAI doesn't return that field.
+      let responseModel: string | undefined;
+      let finishReason: string | undefined;
+      let inputTokens: number | undefined;
+      let outputTokens: number | undefined;
+      let reasoningTokens: number | undefined;
+      let streamErrored = false;
+
       try {
         while (true) {
           const { done, value } = await reader.read();
@@ -202,6 +258,7 @@ export async function POST(request: Request): Promise<Response> {
           if (buffer.length > MAX_SSE_BUFFER_BYTES) {
             // Defense against an upstream that streams without newlines —
             // unbounded buffer growth would leak memory. Tear it down.
+            streamErrored = true;
             controller.error(new Error("Upstream SSE buffer exceeded cap"));
             return;
           }
@@ -224,6 +281,23 @@ export async function POST(request: Request): Promise<Response> {
               if (typeof content === "string" && content.length > 0) {
                 controller.enqueue(encoder.encode(content));
               }
+              // GenAI semantic-convention bookkeeping. The response
+              // model may differ from the request model when OpenAI
+              // routes the request to a versioned snapshot
+              // (e.g. `gpt-5-mini-2026-01-01`). The final usage chunk
+              // arrives with empty `choices` + populated `usage`.
+              if (chunk.model && !responseModel) {
+                responseModel = chunk.model;
+              }
+              const chunkFinishReason = chunk.choices[0]?.finish_reason;
+              if (typeof chunkFinishReason === "string") {
+                finishReason = chunkFinishReason;
+              }
+              if (chunk.usage) {
+                inputTokens = chunk.usage.prompt_tokens;
+                outputTokens = chunk.usage.completion_tokens;
+                reasoningTokens = chunk.usage.completion_tokens_details?.reasoning_tokens;
+              }
             } catch {
               // Malformed/unsupported chunk shape — skip rather than tear
               // down the whole stream for the user.
@@ -231,9 +305,51 @@ export async function POST(request: Request): Promise<Response> {
           }
         }
       } catch (error) {
+        streamErrored = true;
+        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "stream_processing_failed" });
         controller.error(error);
         return;
       } finally {
+        // Finalize the OTel span with whatever GenAI attributes we
+        // captured. Set BEFORE end(); attributes added after end() are
+        // dropped silently by the SDK. The span outlives the Response
+        // return because we hold the ref in this closure.
+        if (responseModel) {
+          span.setAttribute("gen_ai.response.model", responseModel);
+        }
+        if (finishReason) {
+          // GenAI spec models finish reasons as an array (one per
+          // choice). Streaming chat completion has one choice.
+          span.setAttribute("gen_ai.response.finish_reasons", [finishReason]);
+        }
+        if (inputTokens !== undefined) {
+          span.setAttribute("gen_ai.usage.input_tokens", inputTokens);
+        }
+        if (outputTokens !== undefined) {
+          span.setAttribute("gen_ai.usage.output_tokens", outputTokens);
+        }
+        if (reasoningTokens !== undefined) {
+          // Non-standard but parallel to GenAI naming. Reasoning models
+          // (gpt-5 family) bill chain-of-thought tokens separately from
+          // visible-content tokens; surfacing this makes cost dashboards
+          // distinguish "I had to think hard" from "I had to write a lot."
+          span.setAttribute("gen_ai.usage.reasoning_tokens", reasoningTokens);
+        }
+        if (inputTokens !== undefined && outputTokens !== undefined) {
+          const cost = computeChatCostUsd(requestedModel, inputTokens, outputTokens);
+          if (cost !== undefined) {
+            // Non-standard. Approximate USD cost derived from the
+            // model pricing table in `lib/llm-pricing.ts`. Token
+            // attributes above are the canonical signal; cost is
+            // a derived convenience.
+            span.setAttribute("llm.cost_usd", cost);
+          }
+        }
+        if (!streamErrored) {
+          span.setStatus({ code: SpanStatusCode.OK });
+        }
+        span.end();
         controller.close();
       }
     },

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -1,0 +1,26 @@
+import { registerOTel } from "@vercel/otel";
+
+/**
+ * Next.js 16 server-side instrumentation hook.
+ *
+ * `@vercel/otel` wires up the OpenTelemetry SDK with sane defaults:
+ *  - Auto-instruments `fetch` calls (so the outbound OpenAI request
+ *    appears as a child HTTP span without manual wrapping).
+ *  - Adds Vercel deployment context (deployment.id, cloud.region,
+ *    vcs.ref.head.revision, etc.) to every exported span.
+ *  - Routes spans to the Vercel OTLP collector when deployed; no-ops
+ *    locally (no exporter configured = traces stay in process and
+ *    drop on shutdown, which is the correct local-dev behavior).
+ *
+ * GenAI-specific span attributes (gen_ai.system, gen_ai.request.model,
+ * gen_ai.usage.input_tokens, gen_ai.usage.output_tokens, llm.cost_usd)
+ * are set manually in `app/api/chat/route.ts` — auto-instrumentation
+ * gives us the HTTP + fetch envelope; LLM semantic conventions need
+ * application-level knowledge to populate correctly.
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/ (semantic conv)
+ * @see https://vercel.com/docs/observability/otel-overview (Vercel sink)
+ */
+export function register(): void {
+  registerOTel({ serviceName: "coldplay-ai-companion" });
+}

--- a/frontend/lib/llm-pricing.ts
+++ b/frontend/lib/llm-pricing.ts
@@ -1,0 +1,53 @@
+/**
+ * LLM token cost computation for OpenTelemetry span enrichment.
+ *
+ * Emitted as the non-standard `llm.cost_usd` span attribute alongside
+ * the OTel GenAI semantic-convention `gen_ai.usage.input_tokens` and
+ * `gen_ai.usage.output_tokens`. The token attributes are the canonical,
+ * vendor-neutral signal; cost is a derived convenience for at-a-glance
+ * dashboard sanity checks.
+ *
+ * Prices are APPROXIMATE — verify against the OpenAI pricing page
+ * (https://openai.com/api/pricing/) before trusting cost aggregations.
+ * Update this table when pricing changes; rotation cadence is low so
+ * a static table is the right shape (no env override, no remote fetch
+ * adding boot-time latency or a network dependency on the chat path).
+ *
+ * Models not in the table return `undefined` — callers must skip
+ * emitting `llm.cost_usd` rather than emit zero, which would silently
+ * skew aggregate cost dashboards.
+ */
+
+export interface ModelPricing {
+  /** USD per 1,000,000 input (prompt) tokens. */
+  inputPer1M: number;
+  /** USD per 1,000,000 output (completion) tokens. */
+  outputPer1M: number;
+}
+
+/**
+ * Approximate per-million-token pricing for the model dropdown allowlist.
+ * Keep keys in sync with `lib/constants.ts` MODELS array.
+ */
+export const LLM_PRICING: Readonly<Record<string, ModelPricing>> = Object.freeze({
+  "gpt-5-mini": { inputPer1M: 0.25, outputPer1M: 2.0 },
+  "gpt-5": { inputPer1M: 1.25, outputPer1M: 10.0 },
+  "gpt-5.5": { inputPer1M: 15.0, outputPer1M: 60.0 },
+});
+
+/**
+ * Computes USD cost for a chat completion. Returns `undefined` when
+ * the model is not in the pricing table — callers should omit the
+ * `llm.cost_usd` attribute in that case instead of emitting zero.
+ */
+export function computeChatCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number
+): number | undefined {
+  const pricing = LLM_PRICING[model];
+  if (!pricing) return undefined;
+  const inputCost = (inputTokens / 1_000_000) * pricing.inputPer1M;
+  const outputCost = (outputTokens / 1_000_000) * pricing.outputPer1M;
+  return inputCost + outputCost;
+}

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -99,17 +99,35 @@ export type PersistedChatUiState = z.infer<typeof persistedChatUiStateSchema>;
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const openAiStreamChunkSchema = z.object({
-  choices: z
-    .array(
-      z.object({
-        delta: z
-          .object({
-            content: z.string().optional(),
-          })
-          .passthrough(),
-      })
-    )
-    .min(1),
+  // Optional fields — only present on certain chunks. The final chunk
+  // (when `stream_options.include_usage: true`) carries `usage` + empty
+  // `choices`; intermediate chunks carry content deltas with no usage.
+  // We surface these on the OTel span via GenAI semantic conventions.
+  model: z.string().optional(),
+  choices: z.array(
+    z.object({
+      delta: z
+        .object({
+          content: z.string().optional(),
+        })
+        .passthrough(),
+      finish_reason: z.string().nullable().optional(),
+    })
+  ),
+  usage: z
+    .object({
+      prompt_tokens: z.number().int().nonnegative(),
+      completion_tokens: z.number().int().nonnegative(),
+      total_tokens: z.number().int().nonnegative(),
+      completion_tokens_details: z
+        .object({
+          reasoning_tokens: z.number().int().nonnegative().optional(),
+        })
+        .passthrough()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
 });
 
 export type OpenAiStreamChunk = z.infer<typeof openAiStreamChunkSchema>;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
@@ -34,6 +35,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/otel": "^2.1.2",
     "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -32,6 +35,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@vercel/otel':
+        specifier: ^2.1.2
+        version: 2.1.2(@opentelemetry/api-logs@0.216.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -1373,6 +1379,10 @@ packages:
     resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -1391,6 +1401,12 @@ packages:
 
   '@opentelemetry/exporter-trace-otlp-http@0.216.0':
     resolution: {integrity: sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.218.0':
+    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2683,6 +2699,18 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/otel@2.1.2':
+    resolution: {integrity: sha512-PbGyq1lLwWbnftylNcQ6KFxc7DLc8LJdnaU3snM43bgXiWkWsHrgaU/LdUD8sHaSgG8UKuydX/aymNt3J+hzuA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <2.0.0'
+      '@opentelemetry/api-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/instrumentation': '>=0.200.0 <0.300.0'
+      '@opentelemetry/resources': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
+
   '@vercel/prepare-flags-definitions@0.2.1':
     resolution: {integrity: sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==}
 
@@ -3109,6 +3137,9 @@ packages:
 
   cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -4062,6 +4093,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -4665,6 +4700,9 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
@@ -5383,6 +5421,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -7740,6 +7782,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
@@ -7759,6 +7805,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@opentelemetry/otlp-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -8978,6 +9033,16 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/otel@2.1.2(@opentelemetry/api-logs@0.216.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
   '@vercel/prepare-flags-definitions@0.2.1': {}
 
   '@vercel/python-analysis@0.11.1':
@@ -9405,6 +9470,8 @@ snapshots:
   chownr@3.0.0: {}
 
   cjs-module-lexer@1.2.3: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -10383,7 +10450,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.2(debug@4.3.4))
+      retry-axios: 2.6.0(axios@1.15.2)
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -10398,6 +10465,13 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   indent-string@4.0.0: {}
 
@@ -11166,6 +11240,8 @@ snapshots:
   mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
+
+  module-details-from-path@1.0.4: {}
 
   mongodb-connection-string-url@7.0.1:
     dependencies:
@@ -12171,6 +12247,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   requires-port@1.0.0:
     optional: true
 
@@ -12185,7 +12268,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.15.2(debug@4.3.4)):
+  retry-axios@2.6.0(axios@1.15.2):
     dependencies:
       axios: 1.15.2(debug@4.3.4)
     optional: true


### PR DESCRIPTION
## Summary

- Adds `@vercel/otel` registration via `instrumentation.ts` (Next.js 16 hook). Vercel auto-instruments `fetch`/HTTP and routes traces to Vercel Observability when deployed; no-op locally.
- Manual `openai.chat.completions` span in `app/api/chat/route.ts` emits OTel **GenAI semantic conventions** — `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.request.max_tokens`, `gen_ai.request.streaming`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.reasoning_tokens` — plus non-standard `llm.cost_usd` derived from a per-model pricing table.
- New `lib/llm-pricing.ts` with approximate pricing for the three models in the dropdown allowlist. Models not in the table emit no cost attribute (no silent zero-skew on aggregations).
- `lib/schemas.ts` `openAiStreamChunkSchema` relaxed to accept the final usage chunk (empty `choices` + populated `usage`) and optional `model` / `finish_reason` fields.

## Why this shape, not Langfuse

- Langfuse covers ONE surface (chat endpoint). This app has five surfaces that need observability (auth, audio proxy, CSRF, rate-limit, frontend hooks) — all caught by Sentry + OTel auto-instrumentation, none caught by Langfuse-alone.
- OTel is the CNCF vendor-neutral standard. FAANG teams instrument once and swap backends. Langfuse is the startup convenience wrapper around the same primitives.
- Token/cost dashboards (Langfuse's main value-prop) are reconstructed here from GenAI semantic attributes — one fewer SaaS sink in the loop.

## Cost impact

- **Vercel**: marginal. Traces stay inside Vercel infra (no egress); function-time overhead <0.1%; capstone-scale trace volume far below plan quotas.
- **Users**: zero. `stream_options.include_usage` is a format directive, not content — OpenAI does not bill for the usage chunk.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` (biome) clean
- [x] `pnpm test:run` — 172/172 pass
- [x] `pnpm build` succeeds with new instrumentation
- [ ] Deploy to preview; verify `coldplay-ai-companion` service appears in Vercel Observability → Traces tab
- [ ] Verify `openai.chat.completions` span shows `gen_ai.*` attributes after a chat exchange
- [ ] Verify `llm.cost_usd` populates for messages on each of the three model tiers
- [ ] Verify error paths (kill OPENAI_API_KEY → 401 → check span has `SpanStatusCode.ERROR` with semantic message)