### PR TITLE
perf+fix(frontend): lazy-load canvas-confetti + react-markdown via React.lazy + CSP fixes for Sentry/Vercel preview

### DIFF
--- a/frontend/components/chat/markdown-message.tsx
+++ b/frontend/components/chat/markdown-message.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Lazy-loaded assistant message renderer.
+ *
+ * Split into its own module so `MessageList` can pull it via
+ * `React.lazy() + <Suspense>` — pushing `react-markdown` + `remark-gfm`
+ * (~35-45 KB gzipped combined) out of the initial bundle and into a
+ * chunk that's only fetched when an assistant message actually needs
+ * markdown rendering.
+ *
+ * Rendering map below applies multi-channel typographic hierarchy to
+ * the assistant's markdown output:
+ *   - Bold gets a subtle cyan-200 shift (breaks the all-white wall
+ *     without screaming color).
+ *   - List markers (numbers/bullets) take violet-300 — semantic
+ *     emphasis on structure.
+ *   - Inline code → cyan-200 mono on a tinted surface.
+ *   - Links → cyan-300 underlined; consistent with the aurora palette.
+ *
+ * FAANG move: hierarchy applied to semantic patterns, not arbitrarily
+ * to every emphasis.
+ */
+const markdownComponents: Components = {
+  p: ({ children, ...props }) => (
+    <p className="m-0 my-1.5 first:mt-0 last:mb-0" {...props}>
+      {children}
+    </p>
+  ),
+  strong: ({ children, ...props }) => (
+    <strong
+      className="font-semibold text-cyan-200 [text-shadow:0_0_8px_rgba(125,249,255,0.25)]"
+      {...props}
+    >
+      {children}
+    </strong>
+  ),
+  em: ({ children, ...props }) => (
+    <em className="text-white/92 italic" {...props}>
+      {children}
+    </em>
+  ),
+  code: ({ children, className, ...props }) => {
+    const isBlock = typeof className === "string" && className.startsWith("language-");
+    if (isBlock) {
+      return (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code
+        className="rounded-md bg-white/15 px-1.5 py-0.5 font-mono text-[0.88em] text-cyan-100"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children, ...props }) => (
+    <pre
+      className="my-2 overflow-x-auto rounded-lg border border-white/12 bg-white/10 p-3 text-[0.88em]"
+      {...props}
+    >
+      {children}
+    </pre>
+  ),
+  ul: ({ children, ...props }) => (
+    <ul
+      className="my-2 list-outside list-disc space-y-1 pl-5 marker:font-semibold marker:text-cyan-300/85"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }) => (
+    <ol
+      className="my-2 list-outside list-decimal space-y-1 pl-5 marker:font-semibold marker:text-cyan-300/85"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  li: ({ children, ...props }) => (
+    <li className="text-white" {...props}>
+      {children}
+    </li>
+  ),
+  h1: ({ children, ...props }) => (
+    <h1 className="mt-3 mb-1 font-bold text-white text-xl" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="mt-3 mb-1 font-bold text-lg text-white" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="mt-2 mb-1 font-bold text-base text-white" {...props}>
+      {children}
+    </h3>
+  ),
+  a: ({ children, href, ...props }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-cyan-300 underline underline-offset-2 transition hover:text-cyan-200"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({ children, ...props }) => (
+    <blockquote
+      className="my-2 border-violet-400/60 border-l-2 pl-3 text-white/85 italic"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-3 border-white/15 border-t" />,
+};
+
+interface MarkdownMessageProps {
+  content: string;
+}
+
+/**
+ * Default export so `React.lazy(() => import("./markdown-message"))` works
+ * cleanly — `React.lazy` requires a default-export Promise per the React
+ * docs.
+ */
+export default function MarkdownMessage({ content }: MarkdownMessageProps) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/components/chat/message-list.tsx
+++ b/frontend/components/chat/message-list.tsx
@@ -1,121 +1,19 @@
 import { Sparkles, User } from "lucide-react";
-import type { RefObject } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { lazy, type RefObject, Suspense } from "react";
 import { TypewriterText } from "@/components/chat/typewriter-text";
 import { Button } from "@/components/ui/button";
 import type { ChatMessage } from "@/lib/chat-types";
 import { fireOnUserAction } from "@/lib/confetti";
 import { cn } from "@/lib/utils";
 
-// Multi-channel typographic hierarchy for assistant markdown output.
-// - Bold gets a subtle cyan-200 shift (breaks the all-white wall without screaming color).
-// - List markers (numbers/bullets) take violet-300 — semantic emphasis on structure.
-// - Inline code → cyan-200 mono on a tinted surface.
-// - Links → cyan-300 underlined; consistent with the aurora palette.
-// FAANG move: hierarchy applied to semantic patterns, not arbitrarily to every emphasis.
-const markdownComponents: Components = {
-  p: ({ children, ...props }) => (
-    <p className="m-0 my-1.5 first:mt-0 last:mb-0" {...props}>
-      {children}
-    </p>
-  ),
-  strong: ({ children, ...props }) => (
-    <strong
-      className="font-semibold text-cyan-200 [text-shadow:0_0_8px_rgba(125,249,255,0.25)]"
-      {...props}
-    >
-      {children}
-    </strong>
-  ),
-  em: ({ children, ...props }) => (
-    <em className="text-white/92 italic" {...props}>
-      {children}
-    </em>
-  ),
-  code: ({ children, className, ...props }) => {
-    const isBlock = typeof className === "string" && className.startsWith("language-");
-    if (isBlock) {
-      return (
-        <code className={className} {...props}>
-          {children}
-        </code>
-      );
-    }
-    return (
-      <code
-        className="rounded-md bg-white/15 px-1.5 py-0.5 font-mono text-[0.88em] text-cyan-100"
-        {...props}
-      >
-        {children}
-      </code>
-    );
-  },
-  pre: ({ children, ...props }) => (
-    <pre
-      className="my-2 overflow-x-auto rounded-lg border border-white/12 bg-white/10 p-3 text-[0.88em]"
-      {...props}
-    >
-      {children}
-    </pre>
-  ),
-  ul: ({ children, ...props }) => (
-    <ul
-      className="my-2 list-outside list-disc space-y-1 pl-5 marker:font-semibold marker:text-cyan-300/85"
-      {...props}
-    >
-      {children}
-    </ul>
-  ),
-  ol: ({ children, ...props }) => (
-    <ol
-      className="my-2 list-outside list-decimal space-y-1 pl-5 marker:font-semibold marker:text-cyan-300/85"
-      {...props}
-    >
-      {children}
-    </ol>
-  ),
-  li: ({ children, ...props }) => (
-    <li className="text-white" {...props}>
-      {children}
-    </li>
-  ),
-  h1: ({ children, ...props }) => (
-    <h1 className="mt-3 mb-1 font-bold text-white text-xl" {...props}>
-      {children}
-    </h1>
-  ),
-  h2: ({ children, ...props }) => (
-    <h2 className="mt-3 mb-1 font-bold text-lg text-white" {...props}>
-      {children}
-    </h2>
-  ),
-  h3: ({ children, ...props }) => (
-    <h3 className="mt-2 mb-1 font-bold text-base text-white" {...props}>
-      {children}
-    </h3>
-  ),
-  a: ({ children, href, ...props }) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-cyan-300 underline underline-offset-2 transition hover:text-cyan-200"
-      {...props}
-    >
-      {children}
-    </a>
-  ),
-  blockquote: ({ children, ...props }) => (
-    <blockquote
-      className="my-2 border-violet-400/60 border-l-2 pl-3 text-white/85 italic"
-      {...props}
-    >
-      {children}
-    </blockquote>
-  ),
-  hr: () => <hr className="my-3 border-white/15 border-t" />,
-};
+// Lazy-load the markdown renderer so `react-markdown` + `remark-gfm`
+// (~35-45 KB gzipped combined) don't ship in the initial JS bundle.
+// The locked landing page never renders a markdown message, so first-
+// time visitors download zero markdown JS until they actually unlock
+// the chat AND receive an assistant response. Per Next.js lazy-loading
+// docs + React.lazy docs — the imported module must use `export default`
+// (see `markdown-message.tsx`).
+const MarkdownMessage = lazy(() => import("./markdown-message"));
 
 const EXAMPLE_PROMPTS = [
   "Who are the members of Coldplay and what does each one do?",
@@ -301,12 +199,20 @@ export function MessageList({
                               />
                             </p>
                           ) : (
-                            <ReactMarkdown
-                              remarkPlugins={[remarkGfm]}
-                              components={markdownComponents}
+                            // Fallback renders the same raw text — CLS-safe
+                            // because the unformatted paragraph occupies the
+                            // same vertical footprint as the formatted output
+                            // for the ~50-150ms before the markdown chunk
+                            // hydrates. `whitespace-pre-wrap` preserves any
+                            // newlines so the visual layout is essentially
+                            // identical pre/post hydration.
+                            <Suspense
+                              fallback={
+                                <p className="m-0 whitespace-pre-wrap">{message.content}</p>
+                              }
                             >
-                              {message.content}
-                            </ReactMarkdown>
+                              <MarkdownMessage content={message.content} />
+                            </Suspense>
                           )}
                         </div>
                       </div>

--- a/frontend/lib/confetti.ts
+++ b/frontend/lib/confetti.ts
@@ -10,9 +10,39 @@
  * All functions are no-ops on the server (canvas-confetti requires `window`)
  * and when the user has `prefers-reduced-motion: reduce` set — confetti is
  * pure decoration and accessibility comes first.
+ *
+ * Lazy-load posture (per Next.js lazy-loading guide — "Loading External
+ * Libraries" section): the `canvas-confetti` package is ~8 KB gzipped and
+ * is only used on celebration events (key verify, message send). Static
+ * import would pull it into every page's initial JS bundle. Dynamic
+ * `import()` defers the download until the first call, then the module-
+ * level cache below ensures all subsequent calls reuse the resolved
+ * reference. Public API stays synchronous fire-and-forget — call sites
+ * never await.
  */
 
-import confetti from "canvas-confetti";
+// `canvas-confetti` uses CommonJS-style `export = confetti` plus a
+// `declare namespace` for sub-types. With esModuleInterop, the dynamic
+// `import()` returns an object with both a `.default` (the function) and
+// the namespace members spread on top. We import the type for the
+// callable from the static side and resolve it from `mod.default` (with
+// a fallback for bundlers that hoist the function to the module root).
+import type confettiTypeImport from "canvas-confetti";
+
+type ConfettiFn = typeof confettiTypeImport;
+
+let confettiPromise: Promise<ConfettiFn> | null = null;
+
+/**
+ * Returns the cached promise that resolves to the `confetti` callable.
+ * First call kicks off the dynamic chunk download; later calls reuse it.
+ * Returns `null` on the server (canvas-confetti requires `window`).
+ */
+function loadConfetti(): Promise<ConfettiFn> | null {
+  if (typeof window === "undefined") return null;
+  confettiPromise ??= import("canvas-confetti").then((mod) => (mod.default ?? mod) as ConfettiFn);
+  return confettiPromise;
+}
 
 /**
  * Coldplay vibrant palette — pulled from `@theme` tokens in globals.css
@@ -49,15 +79,17 @@ function randomInRange(min: number, max: number): number {
  */
 export function fireBasic(): void {
   if (!shouldFireConfetti()) return;
-  void confetti({
-    particleCount: 120,
-    spread: 72,
-    startVelocity: 38,
-    origin: { x: 0.5, y: 0.7 },
-    colors: COLDPLAY_COLORS,
-    ticks: 220,
-    zIndex: Z_INDEX,
-    scalar: 1.05,
+  void loadConfetti()?.then((confetti) => {
+    void confetti({
+      particleCount: 120,
+      spread: 72,
+      startVelocity: 38,
+      origin: { x: 0.5, y: 0.7 },
+      colors: COLDPLAY_COLORS,
+      ticks: 220,
+      zIndex: Z_INDEX,
+      scalar: 1.05,
+    });
   });
 }
 
@@ -69,16 +101,18 @@ export function fireBasic(): void {
  */
 export function fireRandomDirection(): void {
   if (!shouldFireConfetti()) return;
-  void confetti({
-    particleCount: 90,
-    angle: randomInRange(45, 135),
-    spread: 110,
-    startVelocity: 32,
-    origin: { x: randomInRange(0.25, 0.75), y: randomInRange(0.55, 0.75) },
-    colors: COLDPLAY_COLORS,
-    ticks: 200,
-    zIndex: Z_INDEX,
-    scalar: 0.95,
+  void loadConfetti()?.then((confetti) => {
+    void confetti({
+      particleCount: 90,
+      angle: randomInRange(45, 135),
+      spread: 110,
+      startVelocity: 32,
+      origin: { x: randomInRange(0.25, 0.75), y: randomInRange(0.55, 0.75) },
+      colors: COLDPLAY_COLORS,
+      ticks: 200,
+      zIndex: Z_INDEX,
+      scalar: 0.95,
+    });
   });
 }
 
@@ -88,35 +122,36 @@ export function fireRandomDirection(): void {
  */
 export function fireFireworks(): void {
   if (!shouldFireConfetti()) return;
+  void loadConfetti()?.then((confetti) => {
+    const duration = 5000;
+    const animationEnd = Date.now() + duration;
+    const defaults = {
+      startVelocity: 30,
+      spread: 360,
+      ticks: 60,
+      zIndex: Z_INDEX,
+      colors: COLDPLAY_COLORS,
+    };
 
-  const duration = 5000;
-  const animationEnd = Date.now() + duration;
-  const defaults = {
-    startVelocity: 30,
-    spread: 360,
-    ticks: 60,
-    zIndex: Z_INDEX,
-    colors: COLDPLAY_COLORS,
-  };
-
-  const interval = window.setInterval(() => {
-    const timeLeft = animationEnd - Date.now();
-    if (timeLeft <= 0) {
-      window.clearInterval(interval);
-      return;
-    }
-    const particleCount = 50 * (timeLeft / duration);
-    void confetti({
-      ...defaults,
-      particleCount,
-      origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
-    });
-    void confetti({
-      ...defaults,
-      particleCount,
-      origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
-    });
-  }, 250);
+    const interval = window.setInterval(() => {
+      const timeLeft = animationEnd - Date.now();
+      if (timeLeft <= 0) {
+        window.clearInterval(interval);
+        return;
+      }
+      const particleCount = 50 * (timeLeft / duration);
+      void confetti({
+        ...defaults,
+        particleCount,
+        origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
+      });
+      void confetti({
+        ...defaults,
+        particleCount,
+        origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
+      });
+    }, 250);
+  });
 }
 
 /**
@@ -125,33 +160,34 @@ export function fireFireworks(): void {
  */
 export function fireSideCannons(): void {
   if (!shouldFireConfetti()) return;
+  void loadConfetti()?.then((confetti) => {
+    const end = Date.now() + 3000;
+    const defaults = {
+      spread: 55,
+      ticks: 80,
+      zIndex: Z_INDEX,
+      colors: COLDPLAY_COLORS,
+      startVelocity: 45,
+    };
 
-  const end = Date.now() + 3000;
-  const defaults = {
-    spread: 55,
-    ticks: 80,
-    zIndex: Z_INDEX,
-    colors: COLDPLAY_COLORS,
-    startVelocity: 45,
-  };
-
-  const frame = () => {
-    if (Date.now() > end) return;
-    void confetti({
-      ...defaults,
-      particleCount: 3,
-      angle: 60,
-      origin: { x: 0, y: 0.7 },
-    });
-    void confetti({
-      ...defaults,
-      particleCount: 3,
-      angle: 120,
-      origin: { x: 1, y: 0.7 },
-    });
-    window.requestAnimationFrame(frame);
-  };
-  frame();
+    const frame = () => {
+      if (Date.now() > end) return;
+      void confetti({
+        ...defaults,
+        particleCount: 3,
+        angle: 60,
+        origin: { x: 0, y: 0.7 },
+      });
+      void confetti({
+        ...defaults,
+        particleCount: 3,
+        angle: 120,
+        origin: { x: 1, y: 0.7 },
+      });
+      window.requestAnimationFrame(frame);
+    };
+    frame();
+  });
 }
 
 /**

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -50,12 +50,21 @@ export function proxy(request: NextRequest): NextResponse {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' https: data: blob:",
     "font-src 'self' data:",
-    // `https://*.sentry.io` allows the browser SDK to POST captured
-    // errors to Sentry's regional ingest endpoint (e.g.
-    // `o4511…ingest.us.sentry.io`). Without this, every client-side
-    // error would itself trigger a CSP violation — silencing the very
-    // signal we're trying to capture.
-    "connect-src 'self' https://*.sentry.io",
+    // Sentry browser SDK posts to a deep subdomain — the ingest host
+    // looks like `o4511411649511424.ingest.us.sentry.io`, FOUR levels
+    // deep under `sentry.io`. CSP host wildcards (`*.sentry.io`) only
+    // match ONE subdomain level, so the original wildcard silently
+    // blocked every Sentry event. Match the actual ingest pattern
+    // explicitly. The second entry (without region) is a forward-
+    // compatible safety net for accounts in non-US regions.
+    "connect-src 'self' https://*.ingest.us.sentry.io https://*.ingest.sentry.io",
+    // Vercel preview deploys embed an iframe from `vercel.live` for
+    // the preview toolbar (comments/feedback overlay). Without an
+    // explicit `frame-src`, CSP falls back to `default-src 'self'`
+    // and blocks the iframe → preview deploys log a CSP violation on
+    // every load. Production deploys don't include the toolbar so
+    // this directive is preview-relevant only.
+    "frame-src 'self' https://vercel.live",
     "media-src 'self'",
     "frame-ancestors 'none'",
     "form-action 'self'",

--- a/frontend/tests/message-list.test.tsx
+++ b/frontend/tests/message-list.test.tsx
@@ -130,24 +130,29 @@ describe("<MessageList />", () => {
     expect(within(article).getByText("My question")).toBeInTheDocument();
   });
 
-  it("renders an assistant message with the 'Coldplay AI' label and markdown content", () => {
+  // MessageList renders the markdown subtree via React.lazy + Suspense
+  // (chunk split to keep `react-markdown` + `remark-gfm` out of the
+  // initial JS bundle). In tests, that means the markdown DOM lands
+  // one microtask later than the synchronous fallback — `findBy*`
+  // queries await the hydration; `getBy*` would race the lazy load.
+  it("renders an assistant message with the 'Coldplay AI' label and markdown content", async () => {
     renderList({
       messages: [makeAssistant("**Chris Martin** is the lead vocalist.")],
     });
     const article = screen.getByRole("article", { name: /assistant message/i });
     expect(within(article).getByText("Coldplay AI")).toBeInTheDocument();
     // Bold markdown rendered as <strong> with the cyan-200 class.
-    const strong = within(article).getByText("Chris Martin");
+    const strong = await within(article).findByText("Chris Martin");
     expect(strong.tagName).toBe("STRONG");
   });
 
-  it("opens markdown links in a new tab with rel='noopener noreferrer'", () => {
+  it("opens markdown links in a new tab with rel='noopener noreferrer'", async () => {
     renderList({
       messages: [
         makeAssistant("Visit [the official site](https://example.com/coldplay) for more."),
       ],
     });
-    const link = screen.getByRole("link", { name: /the official site/i });
+    const link = await screen.findByRole("link", { name: /the official site/i });
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", expect.stringMatching(/noopener/));
     expect(link).toHaveAttribute("rel", expect.stringMatching(/noreferrer/));


### PR DESCRIPTION
## Summary

Two atomic commits, both contribute to the Lighthouse Best Practices + Performance score on the next preview run.

### Commit 1 — `fix(csp)`: un-break Sentry + allow Vercel preview iframe

Two bugs surfaced by the previous Lighthouse CI run on PR #66:

- **Sentry has been silently broken since PR #65.** The CSP directive `connect-src https://*.sentry.io` only matches one subdomain level. Sentry's actual ingest host is FOUR levels deep (`o<id>.ingest.us.sentry.io`) so every browser-SDK POST was CSP-blocked. Fixed with `connect-src 'self' https://*.ingest.us.sentry.io https://*.ingest.sentry.io`.
- **Vercel preview toolbar iframe was CSP-blocked.** No explicit `frame-src` directive existed → fell back to `default-src 'self'` and blocked the `vercel.live` iframe. Fixed with `frame-src 'self' https://vercel.live`.

These two fixes alone resolve all four "errors-in-console" entries that dragged Lighthouse BP to 93.

### Commit 2 — `perf(frontend)`: lazy-load via Next.js patterns

Per the [Next.js lazy-loading guide](https://nextjs.org/docs/app/guides/lazy-loading) (read before implementing):

| Module | Pattern | Saved (gzipped) |
|---|---|---|
| `canvas-confetti` | Module-level promise cache + dynamic `import()` in helpers — public API stays synchronous fire-and-forget | ~8 KB |
| `react-markdown` + `remark-gfm` | Extracted to `markdown-message.tsx`, loaded via `React.lazy` + `<Suspense>` with raw-text fallback (CLS-safe) | ~35-45 KB |
| `audio-orchestrator` | **Deliberately skipped** — Chrome autoplay policy needs synchronous AudioContext construction inside a user-gesture frame. Dynamic import breaks that and surfaces an autoplay-policy warning → Lighthouse BP regression. Trade-off rejected. | (would have been ~10-15 KB) |

**Total initial-bundle savings: ~45-55 KB gzipped.** Expected Lighthouse impact: Performance 96 → ~98-100 (Speed Index improvement from less initial JS), BP 93 → ~100 (CSP fixes eliminate the console errors).

## No breaking changes — verified

- `pnpm typecheck` ✅
- `pnpm lint` (biome) ✅
- `pnpm test:run` — **172/172 unit tests pass** (two MessageList tests updated to `findBy*` because the markdown DOM lands one microtask after the Suspense fallback in jsdom)
- `pnpm test:a11y` (Playwright + axe-core) — **2/2 pass, zero WCAG 2.1 AA violations** on both locked + unlocked surfaces
- `pnpm build` ✅
- Manual smoke (to verify post-merge on preview):
  - [ ] Send a chat message → markdown renders correctly after lazy hydration
  - [ ] Enter a valid key → confetti still fires
  - [ ] Toggle Sound → audio still plays (no autoplay-policy regression)

## Docs consulted before writing the code

- [Lazy Loading](https://nextjs.org/docs/app/guides/lazy-loading) — `next/dynamic` vs `React.lazy`, external libraries via inline `import()`
- [Streaming](https://nextjs.org/docs/app/guides/streaming) — Suspense boundaries as hydration units, CLS warning about fallback dimensions
- [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components) — `'use client'` propagation
- [Proxy](https://nextjs.org/docs/app/getting-started/proxy) — Next 16 file convention (no API change needed)

Skipped (correctly): parallel routes (single-route app), PWA (LLM chat needs network), revalidating/caching (no external CMS to cache).