### PR TITLE
chore(security): GitHub Advanced Security baseline — gitleaks + Dependabot + CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# GitHub-native dependency security automation.
+#
+# Two ecosystems tracked:
+#   1. npm (frontend/) — Next.js + React + every test / observability /
+#      AI / lint dep. "npm" is the correct package-ecosystem value for
+#      pnpm projects per GitHub docs (the npm ecosystem supports
+#      pnpm v7-v10 lockfile parsing).
+#   2. github-actions — keeps our workflow action versions current
+#      (actions/checkout, gitleaks-action, codeql-action, etc.).
+#
+# Both run on a weekly schedule with GROUPING so the inbox stays sane:
+# minor + patch version bumps batch into one PR per ecosystem instead
+# of 50. Major bumps still arrive as individual PRs (more risk → more
+# careful review).
+#
+# CVE-flagged security updates fire AD-HOC regardless of schedule —
+# any transitive dep with a known vulnerability gets its own immediate
+# PR independent of the weekly cadence. That's the actual safety net;
+# the version-update cadence is just hygiene.
+
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    # The Next.js app lives at `/frontend`, not repo root.
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      # Local TZ keeps the PR-flood window predictable around start-of-week.
+      timezone: "America/Toronto"
+    # Cap on the open-PR count from this ecosystem. Without this, a
+    # large `pnpm-lock.yaml` could produce dozens of stale dep-update
+    # PRs that nobody triages.
+    open-pull-requests-limit: 10
+    groups:
+      # Minor + patch updates → single PR per week. Major bumps stay
+      # individual because they may carry breaking changes (e.g. a
+      # Tailwind major requires hand-curated migration).
+      minor-and-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Auto-merge labels — opt-in. Add `automerge` label manually on a
+    # batch PR to let it self-merge once CI passes. Off by default;
+    # human review is the safer baseline for a non-trivial dep change.
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    # Scans `.github/workflows/**` for `uses:` lines + any composite
+    # action.yml files at repo root.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    groups:
+      ci-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+name: CodeQL
+
+# Static analysis for OWASP-style vulnerable patterns in our JS/TS code:
+# XSS sinks, prototype pollution, injection, unsafe `eval`, insecure
+# regex, hardcoded credentials in code, ReDoS, taint flow into
+# dangerouslySetInnerHTML, unsafe URL parsing, and ~hundreds of other
+# CWE-categorized queries.
+#
+# Free for public repos with no quota. GitHub's first-party scanner;
+# results land in the repo Security tab and on every PR's checks page.
+#
+# Why this complements the rest of the security stack:
+#   • gitleaks — secrets accidentally committed
+#   • Dependabot — known-vulnerable third-party deps
+#   • CodeQL — vulnerable patterns in code WE wrote ourselves
+#
+# Three orthogonal scanners; together they cover the OWASP Top 10 for
+# Web + most of the OWASP Top 10 for LLM Applications.
+#
+# Triggers:
+#   • pull_request — block merging when new code introduces vulns
+#   • push to main — track main-branch posture over time
+#   • schedule (weekly Mon 06:00 UTC) — re-scan with the latest CodeQL
+#     queries; new vulnerability rules can apply to code that was
+#     clean when originally written. Cron catches that drift.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  # Required to read the source.
+  contents: read
+  # Required to upload the SARIF results so they appear in the Security tab.
+  security-events: write
+  # Required so the action can reach workflow runs (e.g. for matrix metadata).
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` is the unified language pack — covers
+        # both .js and .ts in a single analysis pass (faster than two
+        # separate matrix entries).
+        language: ["javascript-typescript"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` adds queries beyond the default
+          # security pack (more findings, more comprehensive). The
+          # alternative — `security-and-quality` — also adds code-
+          # quality lints, but biome already owns our quality story
+          # locally; duplicating that signal here would be noise.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,47 @@
+name: gitleaks
+
+# Scans every PR + push to main for committed secrets — OpenAI keys,
+# AWS access keys, JWT tokens, GitHub tokens, SSH private keys, generic
+# high-entropy strings, and ~200 other built-in detectors.
+#
+# Free for personal-account repos — no license key required. The
+# GITLEAKS_LICENSE env var is intentionally omitted (it's only required
+# for organization accounts; `lucstp/` is a personal account).
+#
+# Trigger discipline: PR + push to main + manual dispatch. No daily
+# cron — push events already cover every commit that lands; a cron on
+# a no-change day is wasted CI minutes for zero new signal.
+#
+# Complements:
+#   • GitHub's native "Push protection" / "Secret Protection" (catches
+#     well-known secret patterns at push time, before they even reach
+#     the server)
+#   • This action (catches broader high-entropy + custom patterns,
+#     including historical commits in the full fetch-depth scan)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # required so the action can comment findings on PRs
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks can scan every commit, not just
+          # the diff. A secret committed once and then deleted is still
+          # in git history forever — finding it matters.
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Three GitHub-native security scanners, zero external SaaS, free for public repos. **Closes the last remaining item from the original FAANG-grade audit plan.**

| Scanner | What it catches | File |
|---|---|---|
| **gitleaks** | Secrets accidentally committed — OpenAI keys, JWT tokens, SSH keys, AWS credentials, generic high-entropy strings | `.github/workflows/gitleaks.yml` |
| **Dependabot** | Known-vulnerable third-party deps (CVE-flagged transitive packages) | `.github/dependabot.yml` |
| **CodeQL** | Vulnerable patterns in code WE wrote — XSS, prototype pollution, injection, unsafe `eval`, insecure regex, ReDoS, taint flow | `.github/workflows/codeql.yml` |

Three orthogonal threat surfaces, one scanner per. Together they cover OWASP Top 10 for Web + most of OWASP Top 10 for LLM Applications (the chat-content side is already covered by the Promptfoo regression suite from PR #63).

## Cost

**$0** on this public repo for all three scanners. No external API tokens, no licenses required (`lucstp/` is a personal account; gitleaks-action's org-license requirement doesn't apply).

## Deliberately NOT included

- **husky pre-commit hook** for gitleaks — adds a devDep, requires `pnpm install` to register, bypassable with `--no-verify`. For a solo public-repo capstone, the CI Action at merge time IS the security boundary. Add husky later if you ever invite contributors.
- **Renovate** — Dependabot covers our needs.
- **Trivy / Snyk / Semgrep** — no container, no IaC, no need for multi-vendor static analysis. CodeQL handles the JS/TS surface cleanly.

## What you need to do after this merges

1. **GitHub repo Settings → Code security and analysis** — enable these three (~30 seconds total):
   - **Private vulnerability reporting** — free, responsible disclosure path
   - **Dependabot malware alerts** — free, only fires on confirmed malware
   - **Grouped security updates** — reduces PR noise
2. **Do NOT click "Set up" under CodeQL analysis** — the workflow file in this PR IS the Advanced setup. GitHub will auto-detect it and flip the panel to "Configured" within minutes.

That's it. Dependabot self-activates from `.github/dependabot.yml`; gitleaks self-activates from the workflow file.

## Test plan

- [x] All three YAML files validated as parseable (`yaml.safe_load`)
- [x] `pnpm typecheck` clean (no app code touched)
- [x] `pnpm lint` (biome) clean
- [x] `pnpm test:run` — 172/172 still pass
- [ ] First gitleaks workflow run completes (visible in this PR's checks)
- [ ] First CodeQL workflow run completes (visible in this PR's checks + repo Security tab after merge)
- [ ] Dependabot starts proposing PRs the following Monday morning (Toronto TZ)

## Status: original audit plan = fully shipped

After this merges, every Tier from the original L8 FAANG-grade audit is closed: silent-catch sweep, security-critical tests, hook/component/route-handler coverage, image optimization, Promptfoo AI evals, OTel observability, Sentry errors, Lighthouse + axe-core CI, lazy-loading, README sync. **Nothing else mandatory before you submit.**