### PR TITLE
fix(quality): real BP=100 — Zod v4 jitless mode + manual Lighthouse trigger

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,39 +20,51 @@ name: Lighthouse CI
 
 on:
   deployment_status:
+  # Manual trigger from the GitHub Actions UI. Lets a reviewer audit the
+  # current production alias (or any URL) without waiting for a redeploy.
+  # `url` defaults to the production alias so the common case is one click.
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "URL to audit (default: production alias)"
+        required: false
+        default: "https://the-ai-engineer-challenge-coral.vercel.app/"
 
 concurrency:
-  group: lighthouse-${{ github.event.deployment_status.deployment_id || github.ref }}
+  group: lighthouse-${{ github.event.deployment_status.deployment_id || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   lighthouse:
     name: Run Lighthouse on Vercel preview
     runs-on: ubuntu-latest
-    # Only fire on successful preview/production deployments from Vercel.
-    # `target_url` carries the deployed URL; absence is the safety net
-    # in case GitHub fires the event with a partially-formed payload.
+    # Fire on:
+    #  • any `workflow_dispatch` (manual UI trigger — operator chose the URL)
+    #  • a successful Vercel deployment with a non-empty `target_url`
     if: >-
-      github.event.deployment_status.state == 'success'
-      && github.event.deployment_status.target_url != ''
+      github.event_name == 'workflow_dispatch'
+      || (github.event.deployment_status.state == 'success'
+          && github.event.deployment_status.target_url != '')
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run Lighthouse against preview URL
+      - name: Run Lighthouse against target URL
         uses: treosh/lighthouse-ci-action@v12
-        # Vercel Deployment Protection bypass — the config file reads
-        # this env var and emits it as the `x-vercel-protection-bypass`
-        # header on every audit request. Without it, Lighthouse follows
-        # the Vercel SSO redirect and ends up scoring the login page.
-        # Provisioned in Vercel project settings → Deployment Protection
-        # → Protection Bypass for Automation, mirrored as a repo secret.
+        # Vercel Deployment Protection bypass — the puppeteerScript
+        # (`frontend/lighthouse-prepare.cjs`) reads this env var and
+        # mints a `_vercel_jwt` cookie scoped to the deployment origin,
+        # so the audit doesn't follow the Vercel SSO redirect. The
+        # production alias is public and doesn't need this, but
+        # per-deploy preview URLs do.
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         with:
-          urls: ${{ github.event.deployment_status.target_url }}
+          # `workflow_dispatch.inputs.url` wins on manual triggers;
+          # falls back to the Vercel deployment URL on auto-triggers.
+          urls: ${{ github.event.inputs.url || github.event.deployment_status.target_url }}
           configPath: ./frontend/.lighthouserc.cjs
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,3 +1,5 @@
+import "@/lib/zod-config";
+
 import { z } from "zod";
 
 /**

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -1,3 +1,5 @@
+import "@/lib/zod-config";
+
 import { z } from "zod";
 
 import { MODEL_IDS } from "@/lib/constants";

--- a/frontend/lib/zod-config.ts
+++ b/frontend/lib/zod-config.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+/**
+ * Disable Zod v4's JIT validator compiler.
+ *
+ * Why: our production CSP is `script-src 'nonce-X' 'strict-dynamic'` — no
+ * `'unsafe-eval'`. Zod v4's JIT path probes whether `new Function()` is
+ * permitted by actually calling `Function("")` inside a try/catch (see
+ * `zod/src/v4/core/util.ts` — `allowsEval`). Even though Zod gracefully
+ * falls back to its interpreter when the probe throws, the CALL ITSELF
+ * lands in Chrome's DevTools Issues panel as a `ContentSecurityPolicy`
+ * violation (`violatedDirective: "script-src"`,
+ * `contentSecurityPolicyViolationType: "kEvalViolation"`). Lighthouse's
+ * `inspector-issues` audit picks that up, dragging Best Practices to
+ * 96/100. Verified end-to-end via CDP capture against the production
+ * alias.
+ *
+ * `z.config({ jitless: true })` short-circuits the probe entirely (see
+ * `zod/src/v4/core/util.ts:367` — early-return path) so no
+ * `new Function` is ever called. Zod then uses interpreter-mode
+ * validators across the board.
+ *
+ * Perf delta is sub-microsecond on our schema surface (model
+ * allowlist, OpenAI key shape, chat-message shape, env-var shape) —
+ * invisible at any traffic level we serve. The trade is "Best
+ * Practices 96 → 100" in exchange for "interpreter-mode schema
+ * validation," which is free for us.
+ *
+ * Import this module FIRST in any file that defines or imports zod
+ * schemas. The config call is global + memoised by Zod, so re-imports
+ * are no-ops.
+ */
+z.config({ jitless: true });


### PR DESCRIPTION
## Summary

- **The real BP=96 → 100 fix.** PR #73's CSP3 cleanup was correct posture but not the BP=96 cause. CDP-direct capture against the production alias identified the actual culprit: Zod v4's `Function("")` eval-detection probe, which Chrome's Issues panel records as a CSP violation regardless of the catch handler. `z.config({ jitless: true })` short-circuits the probe entirely.
- **Lighthouse `workflow_dispatch` trigger** so the maintainer can re-run the audit anytime from the GitHub Actions UI without waiting for a Vercel redeploy. Defaults to the production alias.

## Root cause (verified end-to-end via CDP, not hypothesized)

After PR #73 merged, `npx lighthouse` against the production alias still scored **BP 96**. A CDP probe (`chrome-remote-interface` listening on `Audits.issueAdded`) captured exactly what Chrome flags:

```
ContentSecurityPolicyIssue
  violatedDirective: "script-src"
  contentSecurityPolicyViolationType: "kEvalViolation"
  sourceCodeLocation: /_next/static/chunks/123ep.xlz2scz.js:3:82795
```

Curling that chunk revealed two `Function(...)` call sites:

1. **Probe** (col 93595): `if (navigator.userAgent.includes("Cloudflare")) return false; try { return Function(""), true } catch(e) { return false }`
2. **Codegen** (col 123806): `compile() { return Function(...this?.args, [...content].join("\n")) }`

Grepping `node_modules` matched **Zod v4**'s `allowsEval` (`zod/src/v4/core/util.ts:364`) and `Doc` codegen class (`zod/src/v4/core/doc.ts`). Zod even ships a test file — `jitless-allows-eval.test.ts` — documenting this exact strict-CSP scenario verbatim, with `z.config({ jitless: true })` as the canonical workaround.

## The fix

`z.config({ jitless: true })` set globally, before any schema is constructed or parsed.

| File | Change |
|---|---|
| `lib/zod-config.ts` (new) | Single side-effect module: `import { z } from "zod"; z.config({ jitless: true });` with the rationale in-file |
| `lib/schemas.ts` | `import "@/lib/zod-config"` as first line, before `import { z }` |
| `lib/env.ts` | Same (server-side parity; cost is negligible, consistency is worth it) |

## Verified on a real Vercel preview deploy

Vercel auto-deployed the branch and Lighthouse CI fired. Report `1779207835509-62160.report.html` against `https://the-ai-engineer-challenge-9e0h338ck-luc-sandbox.vercel.app/`:

| Metric | Before | This PR |
|---|---|---|
| Performance | 99 | 98 (Lighthouse run variance — preview-env noise, not caused by this PR) |
| Accessibility | 100 | **100** |
| **Best Practices** | **96** | **100** ✅ |
| SEO | 63 | 63 (intentional `noindex`) |
| `inspector-issues` | score=0, 1 CSP item | **score=1, 0 items** ✅ |
| `errors-in-console` | score=1 | **score=1** ✅ |

## Trade-off

| | |
|---|---|
| **Cost** | Zod uses interpreter-mode validators instead of JIT-compiled ones. Sub-microsecond perf delta per `.parse()` on our schema surface (4 schemas). Invisible at any traffic level. |
| **Benefit** | BP=96 → 100. Strict CSP posture preserved (no `'unsafe-eval'` reintroduced). |
| **Reversibility** | High. Remove the config call → JIT mode returns. |

## `workflow_dispatch` (manual Lighthouse trigger)

`.github/workflows/lighthouse.yml` now accepts a manual trigger from the Actions UI with an optional `url` input that defaults to the **production alias** (no `vercel.live` toolbar noise). Path: **Actions → Lighthouse CI → Run workflow → (optionally override URL) → Run**.

`if:` condition broadened to allow both event types. `urls:` falls back from `workflow_dispatch.inputs.url` to `deployment_status.target_url`. Concurrency key uses `github.run_id` as fallback so manual triggers don't collide with deployment_status runs.

## Acknowledgment

PR #73 claimed BP=100 from a CSP3 cleanup. That claim wasn't true — the cleanup is correct posture per Google's CSP Evaluator gold standard and worth keeping, but it was not the root cause. The actual cause was dependency-driven (Zod v4's eval probe), only identifiable via runtime CDP capture, not via static config inspection. Lesson recorded in project memory: verify the runtime audit before claiming a root cause.

## Scope locked

Performance 98 vs 99 is Lighthouse run-to-run variance on GitHub-hosted runners auditing preview deploys (with the `vercel.live` toolbar). The metric math: `10 (FCP) + 24 (LCP) + 30 (TBT) + 25 (CLS) + 9 (SI) = 98`. Zod jitless mode affects validator codegen, not paint timing — it is structurally incapable of moving Performance. **Performance work is deliberately out of scope for this PR** and will be evaluated separately against the production alias (via the new `workflow_dispatch` trigger) after merge.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (111 files)
- [x] `pnpm test` clean (172/172)
- [x] `pnpm build` clean
- [x] CDP probe against post-fix local prod build → zero `kEvalViolation`
- [x] Vercel preview deploy of this branch → Lighthouse CI scores **BP 100, `inspector-issues` clean**
- [ ] Post-merge: run `workflow_dispatch` against production alias to capture the canonical 100/100/100/63 evidence

Co-Authored-By: Cursor <cursoragent@cursor.com>